### PR TITLE
Add 6529bot review config

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -1,0 +1,48 @@
+version: 1
+enabled: true
+
+reviewKinds:
+  allowed: [general, followup, wcag, i18n, security, responsiveness]
+  initial: [general, i18n, security, responsiveness]
+  followup: [followup]
+
+commands:
+  enabled: true
+
+lanes:
+  - provider: anthropic
+    model: claude-opus-4-8
+
+limits:
+  maxJobsPerDelivery: 4
+
+admission:
+  publicRepoMode: trusted
+  privateRepoMode: open
+  draftPrMode: allow
+  trustedPermission: write
+  trustedUsers: []
+  trustedTeams: []
+  trustedOrganizations: []
+  denyUsers: []
+
+budget:
+  mode: enforce
+  defaultEstimatedCostUsd: 1
+  caps:
+    repo:
+      dailyUsd: 450
+      weeklyUsd: 3150
+      monthlyUsd: 13500
+    requestor:
+      dailyUsd: 1000
+      weeklyUsd: 7000
+      monthlyUsd: 30000
+    pr:
+      dailyUsd: 100
+      weeklyUsd: 700
+      monthlyUsd: 3000
+    review_kind:
+      dailyUsd: 1000
+      weeklyUsd: 7000
+      monthlyUsd: 30000


### PR DESCRIPTION
## Summary
- add root `.github/6529bot.yml` for 6529bot on 6529-core
- mirror the active FE posture: automatic `general`, `i18n`, `security`, and `responsiveness`; keep `wcag` and `followup` available by command
- allow draft PRs and enforce the same budget shape used by the other active 6529 repos

## Validation
- parsed the config with `6529reviewbot`'s repository config parser
- ran `codex-diff-check --cached -- .github/6529bot.yml`

Signed-off-by: Punk 6529 <108035228+punk6529@users.noreply.github.com>