### PR TITLE
Align renderer reviewbot config with core fanout

### DIFF
--- a/renderer/.github/6529bot.yml
+++ b/renderer/.github/6529bot.yml
@@ -2,8 +2,8 @@ version: 1
 enabled: true
 
 reviewKinds:
-  allowed: [general, followup, wcag, i18n, security, responsiveness]
-  initial: [general, i18n, security, responsiveness]
+  allowed: [general, followup, wcag, i18n, security, glm-swarm, responsiveness]
+  initial: [general, wcag, i18n, security, responsiveness, glm-swarm]
   followup: [followup]
 
 commands:
@@ -14,7 +14,7 @@ lanes:
     model: claude-opus-4-8
 
 limits:
-  maxJobsPerDelivery: 4
+  maxJobsPerDelivery: 6
 
 admission:
   publicRepoMode: trusted


### PR DESCRIPTION
## Summary
- align `renderer/.github/6529bot.yml` with the root core reviewbot fanout
- add `wcag` and `glm-swarm` to the renderer initial set
- raise `maxJobsPerDelivery` from 4 to 6

## Notes
- no application code changes