### PR TITLE
Merge pull-web renderer updates

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,10 @@ MOBILE_APP_SCHEME=
 # 6529 CORE SCHEME
 CORE_SCHEME=core6529
 
+# NEXT.JS DEVELOPMENT ORIGINS (optional, comma-separated)
+# For machine-specific LAN hosts, set this in .env.development.local.
+NEXT_ALLOWED_DEV_ORIGINS=
+
 # IPFS ENDPOINTS
 IPFS_API_ENDPOINT=
 IPFS_GATEWAY_ENDPOINT=

--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -357,11 +357,29 @@ jobs:
             echo "No Jest-related source or test files need coverage."
           fi
 
+      - name: Restore Next.js build cache
+        id: nextjs_build_cache
+        if: needs.plan.outputs.build_required == 'true'
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-node22-nextjs-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'next.config.ts', 'tsconfig*.json', 'postcss.config.*', 'tailwind.config.*') }}-${{ github.event.pull_request.head.sha }}
+          restore-keys: |
+            ${{ runner.os }}-node22-nextjs-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'next.config.ts', 'tsconfig*.json', 'postcss.config.*', 'tailwind.config.*') }}-
+            ${{ runner.os }}-node22-nextjs-
+
       - name: Build app
         if: needs.plan.outputs.build_required == 'true'
         env:
           NODE_ENV: "production"
         run: ./bin/6529 run build
+
+      - name: Save Next.js build cache
+        if: needs.plan.outputs.build_required == 'true' && steps.nextjs_build_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ steps.nextjs_build_cache.outputs.cache-primary-key }}
 
       - name: Install Playwright browser
         if: needs.plan.outputs.playwright_smoke_required == 'true' || needs.plan.outputs.playwright_critical_shell_required == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ CLAUDE.md
 .agent
 
 .direnv/
+
+# Local agent-login wallet material and emitted auth payloads
+ops/skills/6529-agent-login/accounts.json
+ops/skills/6529-agent-login/*.payload.json
+ops/skills/6529-agent-login/*storage-state*.json
+ops/skills/6529-agent-login/*agent-login*.json
+ops/skills/6529-agent-login/*agent-login*.js

--- a/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
@@ -73,6 +73,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 jest.mock("@/services/auth/auth.utils", () => ({
   WALLET_ACCOUNTS_UPDATED_EVENT: "6529-wallet-accounts-updated",
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => [
     {
       address: ACTIVE_ADDRESS,

--- a/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
@@ -284,7 +284,9 @@ describe("SeizeConnectContext switch sync guard", () => {
       expect(mockUseConnectedAccountsUnreadNotifications).toHaveBeenCalledWith([
         inactiveAccount,
       ]);
-      expect(mockUseUnreadNotifications).toHaveBeenCalledWith("alice");
+      expect(mockUseUnreadNotifications).toHaveBeenCalledWith("alice", {
+        enabled: true,
+      });
     });
 
     const unreadMap = JSON.parse(
@@ -346,7 +348,9 @@ describe("SeizeConnectContext switch sync guard", () => {
         activeAccount,
         inactiveAccount,
       ]);
-      expect(mockUseUnreadNotifications).toHaveBeenCalledWith(null);
+      expect(mockUseUnreadNotifications).toHaveBeenCalledWith(null, {
+        enabled: false,
+      });
     });
 
     const unreadMap = JSON.parse(

--- a/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
@@ -48,6 +48,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 
 jest.mock("@/services/auth/auth.utils", () => ({
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => []),
   getWalletAddress: jest.fn(() => null),
   isAuthAddressAuthorized: jest.fn(

--- a/__tests__/components/auth/SeizeConnectContext.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.test.tsx
@@ -61,6 +61,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 // Mock auth utils
 jest.mock("@/services/auth/auth.utils", () => ({
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => []),
   getWalletAddress: jest.fn(() => null),
   isAuthAddressAuthorized: jest.fn(

--- a/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
+++ b/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
@@ -4,6 +4,8 @@ import { renderHook } from "@testing-library/react";
 
 const useQueryMock = jest.fn();
 const getQueryDataMock = jest.fn();
+const commonApiFetchMock = jest.fn();
+const isAuthJwtUsableMock = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (params: unknown) => useQueryMock(params),
@@ -18,13 +20,20 @@ jest.mock("@/hooks/useCapacitor", () => ({
 }));
 
 jest.mock("@/services/api/common-api", () => ({
-  commonApiFetch: jest.fn(),
+  commonApiFetch: (...args: unknown[]) => commonApiFetchMock(...args),
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  isAuthJwtUsable: (...args: unknown[]) => isAuthJwtUsableMock(...args),
 }));
 
 describe("useConnectedAccountsUnreadNotifications", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
     getQueryDataMock.mockReset();
+    commonApiFetchMock.mockReset();
+    isAuthJwtUsableMock.mockReset();
+    isAuthJwtUsableMock.mockReturnValue(true);
   });
 
   it("uses a separate query key from active identity notifications", () => {
@@ -53,5 +62,98 @@ describe("useConnectedAccountsUnreadNotifications", () => {
         ],
       })
     );
+  });
+
+  it("does not enable polling for accounts without usable JWTs", () => {
+    isAuthJwtUsableMock.mockReturnValue(false);
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "expired-jwt",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        queryKey: [
+          QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
+          "connected-account-unread-counts",
+          "v2",
+          [],
+        ],
+      })
+    );
+  });
+
+  it("does not retry unauthorized connected-account notification failures", () => {
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+  });
+
+  it("surfaces unauthorized connected-account failures instead of hiding them as successful polling", async () => {
+    commonApiFetchMock.mockRejectedValue({ status: 401 });
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("blocks connected-account fetches when the JWT expires between renders", async () => {
+    isAuthJwtUsableMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/hooks/useUnreadNotifications.test.ts
+++ b/__tests__/hooks/useUnreadNotifications.test.ts
@@ -3,6 +3,9 @@ import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
 const useQueryMock = jest.fn();
+const commonApiFetchMock = jest.fn();
+const getAuthJwtMock = jest.fn();
+const isAuthJwtUsableMock = jest.fn();
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: any[]) => useQueryMock(...args),
 }));
@@ -12,11 +15,23 @@ jest.mock("@/hooks/useCapacitor", () => ({
   default: () => ({ isCapacitor: false }),
 }));
 
-jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: (...args: unknown[]) => commonApiFetchMock(...args),
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  getAuthJwt: () => getAuthJwtMock(),
+  isAuthJwtUsable: (...args: unknown[]) => isAuthJwtUsableMock(...args),
+}));
 
 describe("useUnreadNotifications", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
+    commonApiFetchMock.mockReset();
+    getAuthJwtMock.mockReset();
+    isAuthJwtUsableMock.mockReset();
+    getAuthJwtMock.mockReturnValue("valid-jwt");
+    isAuthJwtUsableMock.mockReturnValue(true);
   });
 
   it("returns unread when notifications have count", () => {
@@ -33,6 +48,56 @@ describe("useUnreadNotifications", () => {
     );
     expect(result.current.haveUnreadNotifications).toBe(true);
     expect(result.current.notifications).toEqual({ unread_count: 2 });
+  });
+
+  it("does not start polling when caller disables the hook", () => {
+    useQueryMock.mockReturnValue({ data: { unread_count: 2 } });
+
+    const { result } = renderHook(() =>
+      useUnreadNotifications("bob", { enabled: false })
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+    expect(result.current.notifications).toBeUndefined();
+    expect(result.current.haveUnreadNotifications).toBe(false);
+  });
+
+  it("does not start polling when the active auth token is missing or expired", () => {
+    isAuthJwtUsableMock.mockReturnValue(false);
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it("does not retry unauthorized notification failures", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+    expect(queryOptions.retry(0, new Error("temporary failure"))).toBe(true);
+  });
+
+  it("blocks polling before fetch when the token expires between renders", async () => {
+    isAuthJwtUsableMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
   });
 
   it("returns false when no unread notifications", () => {

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -1,8 +1,11 @@
 import { safeLocalStorage } from "@/helpers/safeLocalStorage";
 import {
+  AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
   AUTH_TOKEN_CHANGED_EVENT,
   canStoreAnotherWalletAccount,
   clearAllWalletAuth,
+  clearAgentLoginActiveAddress,
+  getAgentLoginActiveAddress,
   getConnectedWalletAccounts,
   getAuthJwt,
   getRefreshToken,
@@ -12,6 +15,7 @@ import {
   isAuthAddressAuthorized,
   PROFILE_SWITCHED_EVENT,
   removeAuthJwt,
+  setAgentLoginActiveAddress,
   setActiveWalletAccount,
   setAuthJwt,
   syncConnectedWalletProfile,
@@ -243,6 +247,62 @@ describe("auth.utils", () => {
 
     expect(hasActiveSessionV2Auth({ address: "0xaaa" })).toBe(true);
     expect(hasActiveSessionV2Auth({ address: "0xbbb" })).toBe(false);
+  });
+
+  it("returns the active agent-login address only when the marker matches session v2 auth", () => {
+    setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+    setAgentLoginActiveAddress("0xaaa");
+
+    expect(getAgentLoginActiveAddress()).toBe("0xAaA");
+
+    setAgentLoginActiveAddress("0xbbb");
+
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("does not return an agent-login address for unmarked session v2 auth", () => {
+    setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("clears the agent-login marker when the active account changes", () => {
+    const storage = setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+    setAgentLoginActiveAddress("0xAaA");
+
+    setAuthJwt("0xBbB", "jwt-b", null, "role-b", {
+      authSessionVersion: "v2",
+    });
+
+    expect(storage.get(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY)).toBeUndefined();
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("clears the explicit agent-login marker", () => {
+    const storage = setupStorageMocks();
+
+    setAgentLoginActiveAddress("0xAaA");
+    clearAgentLoginActiveAddress();
+
+    expect(storage.get(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY)).toBeUndefined();
   });
 
   it("tracks session v2 auth per stored account instead of only the active account", () => {

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from "react";
+import { getAddress, isAddress } from "viem";
+import {
+  AUTH_STORAGE_KEYS,
+  AUTH_TOKEN_CHANGED_EVENT,
+  PROFILE_SWITCHED_EVENT,
+  WALLET_ACCOUNTS_UPDATED_EVENT,
+  type ConnectedWalletAccount,
+} from "@/services/auth/auth.utils";
+
+const STORAGE_KEYS = AUTH_STORAGE_KEYS;
+
+type Status = {
+  readonly kind: "idle" | "success" | "error";
+  readonly message: string;
+};
+
+type AgentLoginPayload = {
+  readonly account: {
+    readonly profileHandle: string | null;
+  };
+  readonly session: {
+    readonly address: string;
+    readonly role: string | null;
+    readonly accessToken: string;
+    readonly accessTokenExpiresAt: string | null;
+  };
+};
+
+type AgentLoginStoredWalletAccount = ConnectedWalletAccount & {
+  readonly refreshToken: null;
+  readonly jwt: string;
+  readonly profileId: null;
+  readonly authSessionVersion: "v2";
+};
+
+const styles = {
+  main: {
+    minHeight: "100vh",
+    background: "#101418",
+    color: "#f7fafc",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "32px 16px",
+  },
+  panel: {
+    width: "min(720px, 100%)",
+    border: "1px solid #2f3b45",
+    borderRadius: 8,
+    background: "#161c22",
+    padding: 24,
+    boxShadow: "0 24px 60px rgb(0 0 0 / 28%)",
+  },
+  title: {
+    fontSize: 22,
+    lineHeight: 1.25,
+    margin: "0 0 8px",
+  },
+  copy: {
+    color: "#b7c1cc",
+    fontSize: 14,
+    lineHeight: 1.5,
+    margin: "0 0 18px",
+  },
+  label: {
+    display: "block",
+    fontSize: 13,
+    color: "#d8e0e8",
+    marginBottom: 8,
+  },
+  textarea: {
+    width: "100%",
+    minHeight: 220,
+    boxSizing: "border-box",
+    resize: "vertical",
+    borderRadius: 6,
+    border: "1px solid #44525f",
+    background: "#0d1116",
+    color: "#edf3f8",
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+    fontSize: 13,
+    lineHeight: 1.45,
+    padding: 12,
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 10,
+    marginTop: 14,
+  },
+  button: {
+    border: "1px solid #556573",
+    borderRadius: 6,
+    background: "#f7fafc",
+    color: "#101418",
+    minHeight: 38,
+    padding: "0 14px",
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  secondaryButton: {
+    border: "1px solid #556573",
+    borderRadius: 6,
+    background: "transparent",
+    color: "#f7fafc",
+    minHeight: 38,
+    padding: "0 14px",
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  disabledButton: {
+    cursor: "not-allowed",
+    opacity: 0.55,
+  },
+  status: {
+    minHeight: 22,
+    marginTop: 14,
+    fontSize: 13,
+    lineHeight: 1.45,
+  },
+  success: {
+    color: "#79e6a8",
+  },
+  error: {
+    color: "#ff9d9d",
+  },
+} satisfies Record<string, CSSProperties>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${name} must be an object.`);
+  }
+  return value;
+}
+
+function getRequiredString(
+  record: Record<string, unknown>,
+  key: string
+): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function getOptionalString(
+  record: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function parseAgentLoginPayload(rawPayload: string): AgentLoginPayload {
+  const parsed = getRecord(JSON.parse(rawPayload), "Payload");
+  const account = getRecord(parsed["account"], "account");
+  const session = getRecord(parsed["session"], "session");
+  const sessionAddress = getRequiredString(session, "address");
+
+  if (!isAddress(sessionAddress)) {
+    throw new Error("address must be a valid Ethereum address.");
+  }
+
+  return {
+    account: {
+      profileHandle: getOptionalString(account, "profileHandle"),
+    },
+    session: {
+      address: getAddress(sessionAddress),
+      role: getOptionalString(session, "role"),
+      accessToken: getRequiredString(session, "accessToken"),
+      accessTokenExpiresAt: getOptionalString(session, "accessTokenExpiresAt"),
+    },
+  };
+}
+
+function clearStoredRoleKeys(): void {
+  for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+    const key = localStorage.key(index);
+    if (key?.startsWith("auth-role-")) {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+function getCookieExpiresAttribute(expiresAt: string | null): string {
+  if (!expiresAt) {
+    return "";
+  }
+
+  const timestamp = Date.parse(expiresAt);
+  if (!Number.isFinite(timestamp)) {
+    return "";
+  }
+
+  return `; expires=${new Date(timestamp).toUTCString()}`;
+}
+
+function getSecureCookieAttribute(): string {
+  return globalThis.location.protocol === "https:" ? "; Secure" : "";
+}
+
+function dispatchAuthEvents(): void {
+  globalThis.dispatchEvent(new CustomEvent(WALLET_ACCOUNTS_UPDATED_EVENT));
+  globalThis.dispatchEvent(new CustomEvent(AUTH_TOKEN_CHANGED_EVENT));
+  globalThis.dispatchEvent(new CustomEvent(PROFILE_SWITCHED_EVENT));
+}
+
+function applyLoginPayload(payload: AgentLoginPayload): void {
+  const account: AgentLoginStoredWalletAccount = {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+
+  clearStoredRoleKeys();
+  localStorage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
+  localStorage.setItem(STORAGE_KEYS.activeAddress, account.address);
+  localStorage.setItem(STORAGE_KEYS.legacyAddress, account.address);
+  localStorage.setItem(STORAGE_KEYS.agentLoginActiveAddress, account.address);
+  localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
+
+  if (account.role) {
+    localStorage.setItem(STORAGE_KEYS.legacyRole, account.role);
+    localStorage.setItem(
+      `auth-role-${account.address.toLowerCase()}`,
+      account.role
+    );
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.legacyRole);
+  }
+
+  document.cookie = `${STORAGE_KEYS.authCookie}=${encodeURIComponent(
+    account.jwt
+  )}; path=/; SameSite=Strict${getCookieExpiresAttribute(
+    payload.session.accessTokenExpiresAt
+  )}${getSecureCookieAttribute()}`;
+  dispatchAuthEvents();
+}
+
+function clearAuthState(): void {
+  localStorage.removeItem(STORAGE_KEYS.accounts);
+  localStorage.removeItem(STORAGE_KEYS.activeAddress);
+  localStorage.removeItem(STORAGE_KEYS.legacyAddress);
+  localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
+  localStorage.removeItem(STORAGE_KEYS.legacyRole);
+  localStorage.removeItem(STORAGE_KEYS.agentLoginActiveAddress);
+  clearStoredRoleKeys();
+  document.cookie = `${
+    STORAGE_KEYS.authCookie
+  }=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict${getSecureCookieAttribute()}`;
+  dispatchAuthEvents();
+}
+
+function shortAddress(address: string): string {
+  return address.length > 12
+    ? `${address.slice(0, 6)}...${address.slice(-4)}`
+    : address;
+}
+
+function getCurrentAuthStatus(): Status {
+  try {
+    const activeAddress = localStorage.getItem(STORAGE_KEYS.activeAddress);
+    const agentLoginAddress = localStorage.getItem(
+      STORAGE_KEYS.agentLoginActiveAddress
+    );
+    const rawAccounts = localStorage.getItem(STORAGE_KEYS.accounts);
+
+    if (
+      !activeAddress ||
+      !rawAccounts ||
+      agentLoginAddress?.toLowerCase() !== activeAddress.toLowerCase()
+    ) {
+      return {
+        kind: "idle",
+        message: "No active agent auth.",
+      };
+    }
+
+    const parsedAccounts: unknown = JSON.parse(rawAccounts);
+    if (!Array.isArray(parsedAccounts)) {
+      return {
+        kind: "error",
+        message: "Stored agent auth is unreadable.",
+      };
+    }
+
+    const activeAccount = parsedAccounts
+      .filter(isRecord)
+      .find(
+        (account) =>
+          typeof account["address"] === "string" &&
+          account["address"].toLowerCase() === activeAddress.toLowerCase()
+      );
+    const hasToken =
+      typeof activeAccount?.["jwt"] === "string" &&
+      activeAccount["jwt"].trim().length > 0;
+
+    return {
+      kind: hasToken ? "success" : "error",
+      message: hasToken
+        ? `Current account: ${shortAddress(activeAddress)}.`
+        : `Current account: ${shortAddress(activeAddress)} is missing a token.`,
+    };
+  } catch {
+    return {
+      kind: "error",
+      message: "Stored agent auth is unreadable.",
+    };
+  }
+}
+
+function redirectHomeSoon(): void {
+  globalThis.setTimeout(() => {
+    globalThis.location.assign("/");
+  }, 250);
+}
+
+export default function AgentLoginClient() {
+  const [rawPayload, setRawPayload] = useState("");
+  const [status, setStatus] = useState<Status>({
+    kind: "idle",
+    message: "",
+  });
+  const isApplyDisabled = rawPayload.trim().length === 0;
+
+  useEffect(() => {
+    setStatus(getCurrentAuthStatus());
+  }, []);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      const payload = parseAgentLoginPayload(rawPayload);
+      applyLoginPayload(payload);
+      setRawPayload("");
+      setStatus({
+        kind: "success",
+        message: `Logged in as ${shortAddress(payload.session.address)}. Redirecting...`,
+      });
+      redirectHomeSoon();
+    } catch (error) {
+      setStatus({
+        kind: "error",
+        message:
+          error instanceof Error ? error.message : "Could not apply login.",
+      });
+    }
+  };
+
+  const onLogout = () => {
+    clearAuthState();
+    setRawPayload("");
+    setStatus({
+      kind: "success",
+      message: "Logged out. Redirecting...",
+    });
+    redirectHomeSoon();
+  };
+
+  return (
+    <main style={styles.main}>
+      <section aria-labelledby="agent-login-title" style={styles.panel}>
+        <h1 id="agent-login-title" style={styles.title}>
+          Agent Login
+        </h1>
+        <p style={styles.copy}>
+          Paste a local agent login JSON payload. Tokens stay in this browser
+          origin and are not sent to another route.
+        </p>
+        <form onSubmit={onSubmit}>
+          <label htmlFor="agent-login-payload" style={styles.label}>
+            Login payload
+          </label>
+          <textarea
+            id="agent-login-payload"
+            autoCapitalize="off"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            value={rawPayload}
+            onChange={(event) => setRawPayload(event.target.value)}
+            placeholder='{"account": {...}, "session": {...}}'
+            style={styles.textarea}
+          />
+          <div style={styles.actions}>
+            <button
+              type="submit"
+              disabled={isApplyDisabled}
+              style={{
+                ...styles.button,
+                ...(isApplyDisabled ? styles.disabledButton : undefined),
+              }}>
+              Apply
+            </button>
+            <button
+              type="button"
+              onClick={onLogout}
+              style={styles.secondaryButton}>
+              Logout
+            </button>
+          </div>
+        </form>
+        <div
+          aria-live="polite"
+          role="status"
+          style={{
+            ...styles.status,
+            ...(status.kind === "success" ? styles.success : undefined),
+            ...(status.kind === "error" ? styles.error : undefined),
+          }}>
+          {status.message}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/tools/agent-login/page.tsx
+++ b/app/tools/agent-login/page.tsx
@@ -1,0 +1,59 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import { getNodeEnv } from "@/config/env";
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import AgentLoginClient from "./page.client";
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function getHostnameFromHostHeader(hostHeader: string | null): string | null {
+  const firstHost = hostHeader?.split(",")[0]?.trim().toLowerCase();
+  if (!firstHost) {
+    return null;
+  }
+
+  if (firstHost.startsWith("[")) {
+    const closingBracketIndex = firstHost.indexOf("]");
+    return closingBracketIndex > 1
+      ? firstHost.slice(1, closingBracketIndex)
+      : null;
+  }
+
+  return firstHost.split(":")[0] || null;
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith(".local");
+}
+
+function isDevLikeRuntime(): boolean {
+  const nodeEnv = getNodeEnv();
+  return nodeEnv === "development" || nodeEnv === "test" || nodeEnv === "local";
+}
+
+export default async function AgentLoginPage() {
+  const headersList = await headers();
+  const hostname = getHostnameFromHostHeader(
+    headersList.get("host") ?? headersList.get("x-forwarded-host")
+  );
+
+  if (!hostname || !isLocalHostname(hostname) || !isDevLikeRuntime()) {
+    notFound();
+  }
+
+  return <AgentLoginClient />;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    ...getAppMetadata({
+      title: "Agent Login",
+      description: "Local agent login",
+    }),
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -1266,7 +1266,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     useConnectedAccountsUnreadNotifications(jwtPollingStoredConnectedAccounts);
 
   const { notifications: activeUnreadNotifications } = useUnreadNotifications(
-    activeStoredAccount?.profileHandle ?? null
+    hasValidWalletAuth ? (activeStoredAccount?.profileHandle ?? null) : null,
+    { enabled: hasValidWalletAuth }
   );
 
   const connectedAccountUnreadNotifications = useMemo(() => {

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -22,7 +22,9 @@ import { getNodeEnv, publicEnv } from "@/config/env";
 import { MAX_CONNECTED_PROFILES } from "@/constants/constants";
 import {
   canStoreAnotherWalletAccount,
+  clearAgentLoginActiveAddress,
   type ConnectedWalletAccount,
+  getAgentLoginActiveAddress,
   getConnectedWalletAccounts,
   getWalletAddress,
   isAuthAddressAuthorized,
@@ -485,7 +487,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       globalThis.window.location.hostname === "127.0.0.1" ||
       globalThis.window.location.hostname === "::1" ||
       globalThis.window.location.hostname.endsWith(".local"));
-  const impersonatedAddress =
+  const devAuthImpersonatedAddress =
     isDevLikeEnv &&
     isLocalHost &&
     publicEnv.USE_DEV_AUTH === "true" &&
@@ -493,6 +495,17 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       ? getAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       : undefined;
+  const canUseAgentLoginImpersonation =
+    isDevLikeEnv && isLocalHost && publicEnv.USE_DEV_AUTH !== "true";
+  const agentLoginActiveAddress = canUseAgentLoginImpersonation
+    ? getAgentLoginActiveAddress()
+    : null;
+  const agentLoginImpersonatedAddress =
+    agentLoginActiveAddress && isAddress(agentLoginActiveAddress)
+      ? getAddress(agentLoginActiveAddress)
+      : undefined;
+  const impersonatedAddress =
+    agentLoginImpersonatedAddress ?? devAuthImpersonatedAddress;
 
   const refreshStoredConnectedAccounts = useCallback(() => {
     setStoredConnectedAccounts(getConnectedWalletAccounts());
@@ -544,6 +557,23 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
 
     // Use debounced state update to prevent race conditions
     debounceTimeoutRef.current = setTimeout(() => {
+      if (
+        agentLoginImpersonatedAddress &&
+        account.address &&
+        account.isConnected &&
+        isAddress(account.address)
+      ) {
+        const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
+        const isAlreadyConnected =
+          walletState.status === "connected" &&
+          walletState.address === checksummedConnectedAddress;
+        if (!isAlreadyConnected) {
+          setConnected(checksummedConnectedAddress);
+        }
+        return;
+      }
+
       if (impersonatedAddress) {
         const isAlreadyConnected =
           walletState.status === "connected" &&
@@ -561,6 +591,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         isAddress(account.address)
       ) {
         const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isAlreadyConnected =
           walletState.status === "connected" &&
           walletState.address === checksummedConnectedAddress;
@@ -578,6 +609,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         isAddress(account.address)
       ) {
         const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isKnownStoredAccount = storedConnectedAccounts.some(
           (storedAccount) =>
             normalizeAddress(storedAccount.address) ===
@@ -676,6 +708,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         }
 
         const checksummedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isAlreadyConnected =
           walletState.status === "connected" &&
           walletState.address === checksummedAddress;
@@ -711,6 +744,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     setConnected,
     setDisconnected,
     setConnecting,
+    agentLoginImpersonatedAddress,
     impersonatedAddress,
     isAddingConnectedAccount,
   ]);
@@ -989,6 +1023,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
 
       // Normalize address to checksummed format for consistency
       const checksummedAddress = getAddress(address);
+      clearAgentLoginActiveAddress();
       setConnected(checksummedAddress);
       refreshStoredConnectedAccounts();
     },

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -225,11 +225,16 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   const isChildRow = depth === 1;
   const shouldShowExpandControl = canExpand && depth === 0;
   const shouldShowPinButton = showPin && depth === 0;
-  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
-    getSidebarWaveRowLayoutClasses({
-      isChildRow,
-      variant: "app",
-    });
+  const {
+    rowPaddingClasses,
+    rowGapClasses,
+    linkGapClasses,
+    rowHeightClasses,
+    guideLineOffsetClasses,
+  } = getSidebarWaveRowLayoutClasses({
+    isChildRow,
+    variant: "app",
+  });
   const avatarSizeClasses = isChildRow ? "tw-size-7" : "tw-size-8";
   const activeRingClasses = isChildRow
     ? "tw-ring-1 tw-ring-offset-1 tw-ring-offset-iron-900 tw-ring-primary-400"
@@ -254,7 +259,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-14 tw-w-px tw-bg-iron-700/60 md:tw-left-[52px] ${
+          className={`tw-absolute -tw-top-1 ${guideLineOffsetClasses} tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />
@@ -321,8 +326,8 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
         </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
-              <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
+            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+              <div className="-tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
                   href={href}
                   prefetch={false}
@@ -352,7 +357,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
                 )}
               </div>
               {shouldShowDropTime && (
-                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-tight tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
                   <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
                 </div>
               )}

--- a/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
@@ -10,39 +10,45 @@ interface SidebarWaveRowLayoutClasses {
   readonly rowGapClasses: string;
   readonly linkGapClasses: string;
   readonly rowHeightClasses: string;
+  readonly guideLineOffsetClasses: string;
 }
 
 const DEFAULT_LINK_GAP_CLASSES = "tw-space-x-3";
 const DEFAULT_ROW_HEIGHT_CLASSES = "tw-h-full tw-min-h-[62px]";
 const CHILD_ROW_HEIGHT_CLASSES = "tw-h-full tw-min-h-[54px]";
+const CHILD_GUIDE_LINE_OFFSET_CLASSES = "tw-left-[35.5px]";
 
 const rowLayoutByVariant = {
   app: {
     child: {
-      rowPaddingClasses: "tw-pl-[82px] tw-pr-5 md:tw-pl-[78px]",
+      rowPaddingClasses: "tw-pl-[74px] tw-pr-5 md:tw-pl-[70px]",
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: CHILD_GUIDE_LINE_OFFSET_CLASSES,
     },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
       linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
       rowHeightClasses: DEFAULT_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: "",
     },
   },
   web: {
     child: {
-      rowPaddingClasses: "tw-pl-[82px] tw-pr-5 md:tw-pl-[70px]",
+      rowPaddingClasses: "tw-pl-[74px] tw-pr-5 md:tw-pl-[66px]",
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: CHILD_GUIDE_LINE_OFFSET_CLASSES,
     },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
       linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
       rowHeightClasses: DEFAULT_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: "",
     },
   },
 } as const satisfies Record<

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -90,11 +90,16 @@ export const ExpandedWave = ({
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
   const shouldShowDropTime = presentLatestDropTimestamp !== null;
   const rowVerticalPaddingClasses = isChildRow ? "tw-py-1.5" : "tw-py-2";
-  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
-    getSidebarWaveRowLayoutClasses({
-      isChildRow,
-      variant: "web",
-    });
+  const {
+    rowPaddingClasses,
+    rowGapClasses,
+    linkGapClasses,
+    rowHeightClasses,
+    guideLineOffsetClasses,
+  } = getSidebarWaveRowLayoutClasses({
+    isChildRow,
+    variant: "web",
+  });
   const subwavePrefetchTimerRef = useRef<ReturnType<
     typeof globalThis.setTimeout
   > | null>(null);
@@ -155,7 +160,7 @@ export const ExpandedWave = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-14 tw-w-px tw-bg-iron-700/60 md:tw-left-11 ${
+          className={`tw-absolute -tw-top-1 ${guideLineOffsetClasses} tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />
@@ -188,8 +193,8 @@ export const ExpandedWave = ({
         </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
-              <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
+            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+              <div className="-tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
                   href={href}
                   prefetch={false}
@@ -223,7 +228,7 @@ export const ExpandedWave = ({
                 )}
               </div>
               {shouldShowDropTime && (
-                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-tight tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
                   <BrainLeftSidebarWaveDropTime
                     time={presentLatestDropTimestamp}
                   />

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -316,7 +316,7 @@ function WebProfileFeedShortcut({
 
   return (
     <div
-      className={`tw-group tw-flex tw-items-center tw-gap-x-4 tw-px-5 tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
+      className={`tw-group tw-mt-2 tw-flex tw-items-center tw-gap-x-4 tw-px-5 tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
         isActive
           ? "tw-bg-iron-700/60 desktop-hover:hover:tw-bg-iron-700/70"
           : "desktop-hover:hover:tw-bg-iron-800/80"

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -69,7 +69,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { registerRef } = useLayout();
-  const { connectedProfile } = useAuth();
+  const { connectedProfile, isAuthenticated } = useAuth();
+  const hasValidNotificationAuth = isAuthenticated === true;
   const hasAuthenticatedProfile = Boolean(connectedProfile?.handle);
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const shouldShowCurationTabs = Boolean(isApp && waveActive && wave?.id);
@@ -113,7 +114,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
 
   // Get unread notifications using the dedicated hook
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null
+    hasValidNotificationAuth ? (connectedProfile?.handle ?? null) : null,
+    { enabled: hasValidNotificationAuth }
   );
 
   const scrollActiveButtonIntoView = useCallback(

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -40,14 +40,15 @@ function WebSidebar({
 }: WebSidebarProps) {
   const navRef = useRef<{ closeSubmenu: () => void }>(null);
   const pathname = usePathname();
-  const { address } = useSeizeConnectContext();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const { connectedProfile } = useAuth();
   const { profile } = useIdentity({
     handleOrWallet: address || "",
     initialProfile: null,
   });
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null
+    hasValidWalletAuth ? (connectedProfile?.handle ?? null) : null,
+    { enabled: hasValidWalletAuth }
   );
   const profilePath = useMemo(() => {
     if (connectedProfile?.handle) return `/${connectedProfile.handle}`;

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -182,7 +182,7 @@ const NavItemContent = ({
 
   const { name } = item;
   const { icon } = item;
-  const { address, seizeConnect } = useSeizeConnectContext();
+  const { address, seizeConnect, hasValidWalletAuth } = useSeizeConnectContext();
 
   // Add unread notifications logic
   const { connectedProfile } = useAuth();
@@ -193,7 +193,10 @@ const NavItemContent = ({
   });
   const { setTitle } = useTitle();
   const { notifications, haveUnreadNotifications } = useUnreadNotifications(
-    item.name === "Notifications" ? (connectedProfile?.handle ?? null) : null
+    item.name === "Notifications" && hasValidWalletAuth
+      ? (connectedProfile?.handle ?? null)
+      : null,
+    { enabled: hasValidWalletAuth }
   );
 
   // Add unread messages logic

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -40,3 +40,31 @@ export const getDefaultQueryRetry = (errorCallback?: () => void) => {
     },
   };
 };
+
+type QueryErrorWithStatus = {
+  readonly status?: unknown;
+  readonly response?: {
+    readonly status?: unknown;
+  };
+  readonly cause?: {
+    readonly status?: unknown;
+  };
+};
+
+const getQueryErrorStatus = (error: unknown): number | null => {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const statusError = error as QueryErrorWithStatus;
+  const status =
+    statusError.status ??
+    statusError.response?.status ??
+    statusError.cause?.status;
+
+  return typeof status === "number" ? status : null;
+};
+
+export const isUnauthorizedQueryError = (error: unknown): boolean => {
+  return getQueryErrorStatus(error) === 401;
+};

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -17,6 +17,15 @@ const SASS_LOAD_PATHS = [
 const BOOTSTRAP_PROGRESS_PARTIAL =
   "./node_modules/bootstrap/scss/_progress.scss";
 
+function getAllowedDevOrigins(): string[] {
+  return (
+    process.env["NEXT_ALLOWED_DEV_ORIGINS"]
+      ?.split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
 export function sharedConfig(
   publicEnv: PublicEnv,
   assetPrefix: string
@@ -37,7 +46,7 @@ export function sharedConfig(
         "import",
       ],
     },
-    allowedDevOrigins: ["172.20.10.3", "192.168.1.77"],
+    allowedDevOrigins: getAllowedDevOrigins(),
     images: {
       loader: "default",
       remotePatterns: [

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -1,10 +1,15 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { getDefaultQueryRetry } from "@/components/react-query-wrapper/utils/query-utils";
+import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
-import type { ConnectedWalletAccount } from "@/services/auth/auth.utils";
+import {
+  isAuthJwtUsable,
+  type ConnectedWalletAccount,
+} from "@/services/auth/auth.utils";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 
@@ -13,6 +18,66 @@ type ConnectedAccountUnreadCounts = Readonly<Record<string, number>>;
 const POLL_INTERVAL_MS = 15000;
 
 const toAddressKey = (address: string): string => address.toLowerCase();
+
+type UnauthorizedConnectedAccountFailure = {
+  readonly addressKey: string;
+  readonly jwtFingerprint: string;
+};
+
+type ConnectedAccountAuthPollingError = Error & {
+  readonly status: 401;
+  readonly unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[];
+  readonly cause?: unknown;
+};
+
+const createConnectedAccountAuthPollingError = (
+  unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[],
+  cause?: unknown
+): ConnectedAccountAuthPollingError => {
+  const error = new Error(
+    "Connected account unread notification polling requires valid auth"
+  ) as ConnectedAccountAuthPollingError;
+  Object.defineProperty(error, "status", {
+    value: 401,
+    enumerable: true,
+  });
+  Object.defineProperty(error, "unauthorizedFailures", {
+    value: unauthorizedFailures,
+    enumerable: true,
+  });
+  if (cause !== undefined) {
+    Object.defineProperty(error, "cause", {
+      value: cause,
+      enumerable: false,
+    });
+  }
+  return error;
+};
+
+const getUnauthorizedFailuresFromError = (
+  error: unknown
+): readonly UnauthorizedConnectedAccountFailure[] => {
+  if (!isUnauthorizedQueryError(error)) {
+    return [];
+  }
+  if (typeof error !== "object" || error === null) {
+    return [];
+  }
+
+  const failures = (error as { readonly unauthorizedFailures?: unknown })
+    .unauthorizedFailures;
+  return Array.isArray(failures)
+    ? failures.filter(
+        (failure): failure is UnauthorizedConnectedAccountFailure =>
+          typeof failure === "object" &&
+          failure !== null &&
+          typeof (failure as UnauthorizedConnectedAccountFailure).addressKey ===
+            "string" &&
+          typeof (failure as UnauthorizedConnectedAccountFailure)
+            .jwtFingerprint === "string"
+      )
+    : [];
+};
 
 const clampUnreadCount = (count: number | null | undefined): number => {
   if (typeof count !== "number" || Number.isNaN(count) || count <= 0) {
@@ -27,15 +92,34 @@ const fetchUnreadCountForAccount = async (
   if (!account.jwt) {
     return 0;
   }
+  const addressKey = toAddressKey(account.address);
+  const jwtFingerprint = getAuthTokenFingerprint(account.jwt);
 
-  const notifications = await commonApiFetch<ApiNotificationsResponseV2>({
-    endpoint: "v2/notifications",
-    params: { limit: "1" },
-    headers: {
-      Authorization: `Bearer ${account.jwt}`,
-    },
-  });
-  return clampUnreadCount(notifications.unread_count);
+  if (!isAuthJwtUsable(account.jwt)) {
+    throw createConnectedAccountAuthPollingError([
+      { addressKey, jwtFingerprint },
+    ]);
+  }
+
+  try {
+    const notifications = await commonApiFetch<ApiNotificationsResponseV2>({
+      endpoint: "v2/notifications",
+      params: { limit: "1" },
+      headers: {
+        Authorization: `Bearer ${account.jwt}`,
+      },
+      errorMode: "structured",
+    });
+    return clampUnreadCount(notifications.unread_count);
+  } catch (error) {
+    if (isUnauthorizedQueryError(error)) {
+      throw createConnectedAccountAuthPollingError(
+        [{ addressKey, jwtFingerprint }],
+        error
+      );
+    }
+    throw error;
+  }
 };
 
 export function useConnectedAccountsUnreadNotifications(
@@ -43,28 +127,54 @@ export function useConnectedAccountsUnreadNotifications(
 ): ConnectedAccountUnreadCounts {
   const { isCapacitor } = useCapacitor();
   const queryClient = useQueryClient();
+  const [
+    unauthorizedJwtFingerprintByAddress,
+    setUnauthorizedJwtFingerprintByAddress,
+  ] = useState<
+    Readonly<Record<string, string>>
+  >({});
+  const pollableAccounts = useMemo(
+    () =>
+      accounts.filter((account) => {
+        const jwt = account.jwt;
+        if (typeof jwt !== "string" || !isAuthJwtUsable(jwt)) {
+          return false;
+        }
+
+        return (
+          unauthorizedJwtFingerprintByAddress[toAddressKey(account.address)] !==
+          getAuthTokenFingerprint(jwt)
+        );
+      }),
+    [accounts, unauthorizedJwtFingerprintByAddress]
+  );
   const queryKey = [
     QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
     "connected-account-unread-counts",
     "v2",
-    accounts.map((account) => toAddressKey(account.address)),
+    pollableAccounts.map((account) => toAddressKey(account.address)),
   ] as const;
 
   const { data } = useQuery<ConnectedAccountUnreadCounts>({
     queryKey,
     queryFn: async () => {
-      if (accounts.length === 0) {
+      if (pollableAccounts.length === 0) {
         return {};
       }
 
       const previousCounts =
         queryClient.getQueryData<ConnectedAccountUnreadCounts>(queryKey) ?? {};
       const results = await Promise.allSettled(
-        accounts.map((account) => fetchUnreadCountForAccount(account))
+        pollableAccounts.map((account) => fetchUnreadCountForAccount(account))
       );
       const nextCounts: Record<string, number> = {};
+      const unauthorizedFailures: {
+        readonly addressKey: string;
+        readonly jwtFingerprint: string;
+        readonly error: unknown;
+      }[] = [];
 
-      accounts.forEach((account, index) => {
+      pollableAccounts.forEach((account, index) => {
         const addressKey = toAddressKey(account.address);
         const result = results[index];
 
@@ -81,21 +191,77 @@ export function useConnectedAccountsUnreadNotifications(
           return;
         }
 
+        if (account.jwt && isUnauthorizedQueryError(result.reason)) {
+          const nestedUnauthorizedFailures =
+            getUnauthorizedFailuresFromError(result.reason);
+          if (nestedUnauthorizedFailures.length > 0) {
+            nestedUnauthorizedFailures.forEach((failure) => {
+              unauthorizedFailures.push({
+                ...failure,
+                error: result.reason,
+              });
+            });
+            return;
+          }
+
+          unauthorizedFailures.push({
+            addressKey,
+            jwtFingerprint: getAuthTokenFingerprint(account.jwt),
+            error: result.reason,
+          });
+          return;
+        }
+
         const previousCount = previousCounts[addressKey];
         if (typeof previousCount === "number") {
           nextCounts[addressKey] = previousCount;
         }
       });
 
+      const firstUnauthorizedFailure = unauthorizedFailures[0];
+      if (firstUnauthorizedFailure) {
+        throw createConnectedAccountAuthPollingError(
+          unauthorizedFailures.map(({ addressKey, jwtFingerprint }) => ({
+            addressKey,
+            jwtFingerprint,
+          })),
+          firstUnauthorizedFailure.error
+        );
+      }
+
       return nextCounts;
     },
-    enabled: accounts.length > 0,
+    enabled: pollableAccounts.length > 0,
     refetchInterval: POLL_INTERVAL_MS,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getDefaultQueryRetry(),
+    retry: (failureCount: number, error: unknown) => {
+      const unauthorizedFailures = getUnauthorizedFailuresFromError(error);
+      if (unauthorizedFailures.length > 0) {
+        setUnauthorizedJwtFingerprintByAddress((previous) => {
+          let didChange = false;
+          const next = { ...previous };
+          for (const failure of unauthorizedFailures) {
+            if (next[failure.addressKey] !== failure.jwtFingerprint) {
+              next[failure.addressKey] = failure.jwtFingerprint;
+              didChange = true;
+            }
+          }
+          return didChange ? next : previous;
+        });
+        return false;
+      }
+      if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+
+      return failureCount < 3;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
   });
 
   return data ?? {};

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -1,41 +1,133 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { getDefaultQueryRetry } from "@/components/react-query-wrapper/utils/query-utils";
-export function useUnreadNotifications(handle: string | null) {
+import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
+import { getAuthJwt, isAuthJwtUsable } from "@/services/auth/auth.utils";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
+
+interface UseUnreadNotificationsOptions {
+  readonly enabled?: boolean | undefined;
+}
+
+type AuthPollingError = Error & {
+  readonly status: 401;
+  readonly authPollingKey: string;
+  readonly cause?: unknown;
+};
+
+const createAuthPollingError = (
+  authPollingKey: string,
+  cause?: unknown
+): AuthPollingError => {
+  const error = new Error(
+    "Unread notification polling requires valid auth"
+  ) as AuthPollingError;
+  Object.defineProperty(error, "status", {
+    value: 401,
+    enumerable: true,
+  });
+  Object.defineProperty(error, "authPollingKey", {
+    value: authPollingKey,
+    enumerable: true,
+  });
+  if (cause !== undefined) {
+    Object.defineProperty(error, "cause", {
+      value: cause,
+      enumerable: false,
+    });
+  }
+  return error;
+};
+
+const getAuthPollingKeyFromError = (error: unknown): string | null => {
+  if (!isUnauthorizedQueryError(error)) {
+    return null;
+  }
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const authPollingKey = (error as { readonly authPollingKey?: unknown })
+    .authPollingKey;
+  return typeof authPollingKey === "string" ? authPollingKey : null;
+};
+
+export function useUnreadNotifications(
+  handle: string | null,
+  options: UseUnreadNotificationsOptions = {}
+) {
   const { isCapacitor } = useCapacitor();
+  const authJwt = getAuthJwt();
+  const hasUsableAuthJwt = isAuthJwtUsable(authJwt);
+  const authPollingKey = `${handle ?? ""}:${getAuthTokenFingerprint(authJwt)}`;
+  const [blockedAuthPollingKey, setBlockedAuthPollingKey] = useState<
+    string | null
+  >(null);
+  const isAuthPollingBlocked = blockedAuthPollingKey === authPollingKey;
+  const isEnabled =
+    !!handle &&
+    options.enabled !== false &&
+    hasUsableAuthJwt &&
+    !isAuthPollingBlocked;
 
   const { data: notifications } = useQuery<ApiNotificationsResponseV2>({
     queryKey: [
       QueryKey.IDENTITY_NOTIFICATIONS,
       { identity: handle, limit: "1", version: "v2" },
     ],
-    queryFn: async () =>
-      await commonApiFetch<ApiNotificationsResponseV2>({
-        endpoint: `v2/notifications`,
-        params: {
-          limit: "1",
-        },
-      }),
-    enabled: !!handle,
+    queryFn: async () => {
+      if (!isAuthJwtUsable(getAuthJwt())) {
+        throw createAuthPollingError(authPollingKey);
+      }
+
+      try {
+        return await commonApiFetch<ApiNotificationsResponseV2>({
+          endpoint: `v2/notifications`,
+          params: {
+            limit: "1",
+          },
+          errorMode: "structured",
+        });
+      } catch (error) {
+        if (isUnauthorizedQueryError(error)) {
+          throw createAuthPollingError(authPollingKey, error);
+        }
+        throw error;
+      }
+    },
+    enabled: isEnabled,
     refetchInterval: 30000,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getDefaultQueryRetry(),
+    retry: (failureCount: number, error: unknown) => {
+      const blockedKey = getAuthPollingKeyFromError(error);
+      if (blockedKey) {
+        setBlockedAuthPollingKey((previous) =>
+          previous === blockedKey ? previous : blockedKey
+        );
+        return false;
+      }
+      if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+
+      return failureCount < 3;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
   });
 
-  const [haveUnreadNotifications, setHaveUnreadNotifications] = useState(false);
+  const effectiveNotifications = isEnabled ? notifications : undefined;
+  const haveUnreadNotifications =
+    (effectiveNotifications?.unread_count ?? 0) > 0;
 
-  useEffect(() => {
-    setHaveUnreadNotifications(!!notifications?.unread_count);
-  }, [notifications]);
-
-  return { notifications, haveUnreadNotifications };
+  return { notifications: effectiveNotifications, haveUnreadNotifications };
 }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -14,6 +14,7 @@
     "entry": [
       "scripts/**/*.{ts,js,cjs,mjs}",  // local CLIs used via package.json scripts
       "bin/**/*.mjs",                // repo-local Node CLIs launched from shell helpers
+      "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
       "app/**/route.{ts,tsx}",         // Next App Router route handlers (if used)
       "standalone/standalone-memes-mint/src/app/layout.tsx",
       "standalone/standalone-memes-mint/src/app/page.tsx",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -52,9 +52,15 @@
       "title": "6529 FAQ",
       "aliases": [
         "faq",
+        "6529",
+        "6529.io",
         "6529 faq",
+        "what is 6529.io",
         "about faq",
         "what is 6529",
+        "what is 6529 trying to do",
+        "what is 6529 building",
+        "what is the goal of 6529",
         "how do i get started",
         "how does 6529 work",
         "what can i do on 6529"
@@ -69,17 +75,71 @@
         "memes",
         "tdh",
         "rep",
-        "nic"
+        "nic",
+        "network",
+        "state",
+        "coordination",
+        "public",
+        "goods"
       ],
       "facts": [
         "The 6529 FAQ lives at /about/faq.",
-        "The FAQ explains what 6529 is, how to get started, Waves, profiles, TDH, REP, NIC, The Memes, Meme drops, and related core product concepts.",
+        "6529 and 6529.io refer to the same product ecosystem in user questions.",
+        "6529 is building a decentralized network state: a permissionless global network society that funds, builds, and coordinates public-goods work across art, science, culture, and technology.",
+        "In product terms, 6529 is not only an NFT collection site; it is a coordination system built around wallet identity, profiles, The Memes, Meme Lab, Gradients, NextGen, Waves, voting, groups, delegation, REP/CIC reputation, TDH/xTDH network metrics, open data, minting/claims infrastructure, and help tooling such as @help6529.",
+        "The long-term goal is nation-scale positive impact.",
+        "The core idea is to extend what Bitcoin and Ethereum proved for money and code into human coordination itself, so communities can organize, allocate attention, vote, build, and distribute work permissionlessly.",
         "Use the FAQ when users ask broad getting-started questions or ask where general 6529 product explanations live."
       ],
       "canonical_path": "/about/faq",
       "related_paths": ["/", "/waves", "/network", "/about/the-memes"],
       "tags": ["about", "faq", "getting-started"],
       "source_refs": ["components/about/AboutFAQ.tsx"]
+    },
+    {
+      "id": "about.terms-of-service",
+      "kind": "route",
+      "title": "Terms of Service",
+      "aliases": [
+        "terms of service",
+        "terms",
+        "tos",
+        "6529 terms",
+        "6529 terms of service",
+        "platform terms",
+        "legal terms",
+        "what are terms of service"
+      ],
+      "keywords": [
+        "terms",
+        "service",
+        "legal",
+        "platform",
+        "privacy",
+        "copyright",
+        "liability",
+        "arbitration",
+        "sanctions",
+        "cc0"
+      ],
+      "facts": [
+        "The Terms of Service page lives at /about/terms-of-service.",
+        "The page defines the terms for using the 6529 platform and was last updated February 23, 2023.",
+        "The terms cover platform access, 6529 NFTs, incorporated about pages, privacy, copyright, delegation and consolidation, wallet responsibility, phishing, CC0, disclaimers, liability limits, arbitration, and related legal topics.",
+        "Use this page when users ask where the 6529 Terms of Service live or ask about the public legal terms for using 6529.io."
+      ],
+      "canonical_path": "/about/terms-of-service",
+      "related_paths": [
+        "/about/privacy-policy",
+        "/about/cookie-policy",
+        "/about/copyright",
+        "/dispute-resolution"
+      ],
+      "tags": ["about", "terms", "legal"],
+      "source_refs": [
+        "components/about/AboutTermsOfService.tsx",
+        "components/footer/Footer.tsx"
+      ]
     },
     {
       "id": "about.nakamoto-threshold",
@@ -595,22 +655,44 @@
         "total",
         "days",
         "held",
+        "raw",
         "boost",
         "boosted",
         "unboosted",
+        "edition",
+        "weighting",
         "metric",
         "rate",
-        "hodl"
+        "hodl",
+        "category",
+        "sets",
+        "leaderboard",
+        "levels"
       ],
       "facts": [
-        "TDH stands for Total Days Held.",
+        "TDH means Total Days Held.",
         "TDH does not stand for Total Dynamic Head.",
-        "TDH is a time-weighted NFT holding metric that starts from days held and applies edition-size weighting plus active boosters.",
-        "TDH updates on a daily cadence and is used across Network surfaces.",
-        "The Memes and other NFT surfaces can show a per-card TDH or HODL rate."
+        "TDH is 6529's time-weighted holding metric for eligible NFTs.",
+        "Conceptually, TDH measures long-term participation and skin in the 6529 ecosystem.",
+        "Each eligible NFT contributes value based on how long it has been held; that base holding time is then adjusted by edition-size weighting and by collection boosters.",
+        "The calculation has three layers: unweighted days, edition weighting, and boosts.",
+        "Unweighted days means each NFT contributes 1 unit per day it is held.",
+        "Edition weighting means days held are multiplied by a HODL or edition-size rate; on the frontend TDH page, FirstGM with edition size 3,941 is the 1.0 baseline.",
+        "Boosts multiply weighted TDH by active boosters based on what the holder owns.",
+        "The backend stores the distinctions separately: tdh__raw is raw full days held, tdh is raw days multiplied by HODL or edition weighting, and boosted_tdh is weighted TDH multiplied by the active boost.",
+        "Current TDH 1.4 rules use the higher of Category A or Category B boosters, plus Category C.",
+        "Category A is the complete Meme Card set boost, with diminishing additional-set boosts.",
+        "Category B covers season, genesis, and nakamoto set boosts.",
+        "Category C is the Gradient boost, up to 5 Gradients.",
+        "TDH is calculated daily at 00:00 UTC and is used throughout the network: profiles, leaderboards, Levels, groups, Network views, Waves voting and eligibility, and public data."
       ],
       "canonical_path": "/network/tdh",
-      "related_paths": ["/network/definitions", "/network/tdh/historic-boosts"],
+      "related_paths": [
+        "/network/definitions",
+        "/network/tdh/historic-boosts",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "tdh", "glossary"],
       "source_refs": [
         "ops/docs/network/feature-tdh-boost-rules.md",
@@ -645,7 +727,12 @@
         "For a single TDH explanation, point users to the TDH page."
       ],
       "canonical_path": "/network/definitions",
-      "related_paths": ["/network/tdh", "/network/levels"],
+      "related_paths": [
+        "/network/tdh",
+        "/network/tdh/historic-boosts",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "glossary"],
       "source_refs": ["ops/docs/network/feature-network-definitions.md"]
     },
@@ -669,19 +756,52 @@
       "id": "network.xtdh",
       "kind": "glossary",
       "title": "xTDH",
-      "aliases": ["xtdh", "x tdh", "extended tdh", "grants"],
+      "aliases": [
+        "xtdh",
+        "x tdh",
+        "extended tdh",
+        "what is xtdh",
+        "what is x tdh",
+        "xtdh grants",
+        "xTDH grants",
+        "grants"
+      ],
       "keywords": [
         "xtdh",
+        "tdh",
+        "extension",
+        "external",
+        "eligible",
+        "erc721",
+        "coefficient",
         "grants",
         "received",
         "granted",
+        "produced",
+        "allocation",
+        "tokens",
+        "collections",
         "network",
         "profile"
       ],
       "facts": [
-        "xTDH is an extended TDH-related surface with granted and received views on profiles.",
-        "Profile xTDH information is available under /{user}/xtdh when visible.",
-        "Network xTDH overview and formulas live under the Network area."
+        "xTDH is an extension of TDH that lets TDH-like network participation flow beyond core 6529 holders to other NFT holders and communities.",
+        "xTDH can be earned by holding eligible cards outside The Memes ecosystem.",
+        "The frontend /network/xtdh page describes xTDH as an extension of TDH that helps include other NFT holders in the 6529 ecosystem and offer them the benefits of TDH.",
+        "xTDH tracks how much xTDH your Memes produce, how much xTDH you receive from grants on tokens you own, and how much xTDH you have granted away.",
+        "Produced xTDH comes from TDH production: produced_xTDH_today = TDH gained today * xTDH_coefficient.",
+        "The current backend coefficient is 0.1.",
+        "Daily xTDH rate is xtdh_rate = produced_today - granted_out_today + received_today.",
+        "Total xTDH accumulates as xtdh_total = xtdh_total_previous + xtdh_rate.",
+        "The key idea is grants: a profile that produces xTDH can grant future xTDH flow to all tokens in an external ERC-721 collection or to a selected subset of tokens.",
+        "If you own a token with an active grant, you receive your share of that grant while you own the token.",
+        "Per-token grant flow is grant_amount_per_token = rate / denominator, where the denominator is either the collection total supply for full-collection grants or the number of selected tokens for partial grants.",
+        "Transfers inside the same consolidation group do not reset the ownership window; sales or transfers across groups do reset it.",
+        "The first grant increment requires the grant and token ownership to have matured past the required midnight or 24-hour windows.",
+        "xTDH is not simply TDH for external NFTs; it is a grant and allocation layer where TDH producers create xTDH, can grant future production outward, external token owners can receive it, and ungranted or ineligible flow remains with the grantor.",
+        "No produced xTDH is intended to disappear; it is allocated to someone.",
+        "The live xTDH allocations dashboard at /xtdh shows network-wide stats and lets users drill down through Collections, Tokens, Contributors, and Grant details.",
+        "Profile xTDH information is available under /{user}/xtdh when visible."
       ],
       "canonical_path": "/network/xtdh",
       "related_paths": ["/{user}/xtdh", "/network"],
@@ -709,9 +829,58 @@
         "A dedicated Network TDH health route exists under /network/health/network-tdh."
       ],
       "canonical_path": "/network/health",
-      "related_paths": ["/network/health/network-tdh"],
+      "related_paths": ["/network/health/network-tdh", "/network/tdh"],
       "tags": ["network", "health"],
       "source_refs": ["ops/docs/network/feature-health-dashboard.md"]
+    },
+    {
+      "id": "network.tdh-stats",
+      "kind": "route",
+      "title": "Network TDH stats",
+      "aliases": [
+        "network tdh stats",
+        "network stats",
+        "tdh stats",
+        "tdh history",
+        "tdh charts",
+        "global tdh history",
+        "network tdh health",
+        "network tdh chart",
+        "network tdh page"
+      ],
+      "keywords": [
+        "network",
+        "tdh",
+        "stats",
+        "history",
+        "charts",
+        "global",
+        "daily",
+        "change",
+        "checkpoint",
+        "health"
+      ],
+      "facts": [
+        "Network TDH stats live at /network/health/network-tdh.",
+        "The page shows global TDH history in a fixed 10-row view.",
+        "It includes summary values for Network TDH, Daily Change, and Daily % Change.",
+        "It includes checkpoint estimates for the next 250,000,000 TDH checkpoints.",
+        "It shows Total TDH, Net TDH Daily Change, Created TDH Daily Change, and Destroyed TDH Change charts.",
+        "Each chart has boosted, unboosted, and unweighted series.",
+        "Use Network TDH stats when users ask for TDH history, TDH charts, global TDH movement, or deeper Network TDH health information."
+      ],
+      "canonical_path": "/network/health/network-tdh",
+      "related_paths": [
+        "/network/tdh",
+        "/network/definitions",
+        "/network/tdh/historic-boosts",
+        "/network/health"
+      ],
+      "tags": ["network", "tdh", "stats", "health"],
+      "source_refs": [
+        "app/network/health/network-tdh/page.tsx",
+        "ops/docs/network/feature-network-stats.md"
+      ]
     },
     {
       "id": "network.activity",
@@ -1315,6 +1484,57 @@
       ]
     },
     {
+      "id": "delegation.wallet-checker",
+      "kind": "route",
+      "title": "Wallet Checker",
+      "aliases": [
+        "wallet checker",
+        "check wallet",
+        "check my wallet",
+        "check wallet architecture",
+        "check my wallet architecture",
+        "view delegations",
+        "view consolidations",
+        "view delegations and consolidations",
+        "check delegations",
+        "check consolidations",
+        "active delegations",
+        "active consolidations"
+      ],
+      "keywords": [
+        "wallet",
+        "checker",
+        "check",
+        "view",
+        "delegation",
+        "delegations",
+        "manager",
+        "consolidation",
+        "consolidations",
+        "architecture",
+        "address",
+        "ens"
+      ],
+      "facts": [
+        "Wallet Checker lives at /delegation/wallet-checker.",
+        "Wallet Checker is a read-only diagnostics page for one wallet.",
+        "It checks delegations, delegation managers, and consolidation relationships for an entered Ethereum address or .eth ENS.",
+        "It can show Delegations, Active Minting Delegation for The Memes, Delegation Managers, Consolidations, Active Consolidation, and Incomplete Consolidation.",
+        "Use Wallet Checker when users ask how to check or view active delegations, consolidations, delegation managers, or wallet-architecture-related setup for an address."
+      ],
+      "canonical_path": "/delegation/wallet-checker",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases",
+        "/delegation/delegation-center"
+      ],
+      "tags": ["delegation", "wallet", "checker", "diagnostics"],
+      "source_refs": [
+        "ops/docs/delegation/feature-wallet-checker.md",
+        "components/delegation/delegation-page-metadata.ts"
+      ]
+    },
+    {
       "id": "delegation.register-consolidation-doc",
       "kind": "workflow",
       "title": "How to Register a Consolidation",
@@ -1453,6 +1673,7 @@
       ],
       "canonical_path": "/delegation/wallet-architecture",
       "related_paths": [
+        "/delegation/wallet-checker",
         "/delegation/consolidation-use-cases",
         "/delegation/delegation-faq/register-consolidation",
         "/delegation/register-consolidation",
@@ -3790,7 +4011,12 @@
         "Use the main TDH page for the current TDH explanation."
       ],
       "canonical_path": "/network/tdh/historic-boosts",
-      "related_paths": ["/network/tdh"],
+      "related_paths": [
+        "/network/tdh",
+        "/network/definitions",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "tdh", "historic"],
       "source_refs": [
         "app/network/tdh/historic-boosts/page.tsx",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -47,6 +47,41 @@
       ]
     },
     {
+      "id": "about.faq",
+      "kind": "route",
+      "title": "6529 FAQ",
+      "aliases": [
+        "faq",
+        "6529 faq",
+        "about faq",
+        "what is 6529",
+        "how do i get started",
+        "how does 6529 work",
+        "what can i do on 6529"
+      ],
+      "keywords": [
+        "faq",
+        "about",
+        "6529",
+        "started",
+        "profile",
+        "waves",
+        "memes",
+        "tdh",
+        "rep",
+        "nic"
+      ],
+      "facts": [
+        "The 6529 FAQ lives at /about/faq.",
+        "The FAQ explains what 6529 is, how to get started, Waves, profiles, TDH, REP, NIC, The Memes, Meme drops, and related core product concepts.",
+        "Use the FAQ when users ask broad getting-started questions or ask where general 6529 product explanations live."
+      ],
+      "canonical_path": "/about/faq",
+      "related_paths": ["/", "/waves", "/network", "/about/the-memes"],
+      "tags": ["about", "faq", "getting-started"],
+      "source_refs": ["components/about/AboutFAQ.tsx"]
+    },
+    {
       "id": "navigation.search",
       "kind": "ui_affordance",
       "title": "Header search",
@@ -1064,6 +1099,264 @@
         "ops/docs/delegation/feature-delegation-action-flows.md",
         "ops/docs/delegation/flow-delegation-center-to-onchain-actions.md",
         "ops/docs/delegation/source-of-truth-spec.md"
+      ]
+    },
+    {
+      "id": "delegation.wallet-architecture",
+      "kind": "workflow",
+      "title": "Wallet Architecture",
+      "aliases": [
+        "wallet architecture",
+        "4 wallet architecture",
+        "four wallet architecture",
+        "three address protocol",
+        "tap",
+        "vault wallet",
+        "transaction wallet",
+        "minting wallet",
+        "hot wallet",
+        "cold wallet",
+        "wallet setup",
+        "safe wallet architecture"
+      ],
+      "keywords": [
+        "wallet",
+        "architecture",
+        "vault",
+        "transaction",
+        "minting",
+        "hot",
+        "cold",
+        "safe",
+        "gnosis",
+        "tap",
+        "phishing",
+        "malware"
+      ],
+      "facts": [
+        "Wallet Architecture lives at /delegation/wallet-architecture and is part of the Delegation Center docs.",
+        "The recommended architecture separates a vault wallet for long-term NFT storage, a transaction wallet for trusted marketplace activity, and a minting wallet for unknown or higher-risk minting activity.",
+        "The docs call this the Three Address Protocol, or TAP, and explain how separate wallets reduce phishing, malware, and malicious-site risk.",
+        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet."
+      ],
+      "canonical_path": "/delegation/wallet-architecture",
+      "related_paths": [
+        "/delegation/delegation-faq",
+        "/delegation/consolidation-use-cases",
+        "/delegation/register-delegation",
+        "/delegation/register-consolidation"
+      ],
+      "tags": ["delegation", "wallet", "security", "architecture"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-overview-wallet-architecture.html",
+        "components/delegation/delegation-page-metadata.ts"
+      ]
+    },
+    {
+      "id": "delegation.consolidation-use-cases",
+      "kind": "workflow",
+      "title": "Consolidation Use Cases",
+      "aliases": [
+        "consolidation use cases",
+        "4 wallet consolidation",
+        "four wallet consolidation",
+        "three wallet consolidation",
+        "two wallet consolidation",
+        "compromised wallet consolidation",
+        "consolidation architecture",
+        "how do consolidations affect tdh"
+      ],
+      "keywords": [
+        "consolidation",
+        "wallet",
+        "wallets",
+        "tdh",
+        "cards",
+        "unique",
+        "vault",
+        "minting",
+        "transaction",
+        "compromised",
+        "reciprocal"
+      ],
+      "facts": [
+        "Consolidation Use Cases lives at /delegation/consolidation-use-cases.",
+        "Consolidations help 6529 treat multiple wallets controlled by one collector together for metrics such as total cards, unique cards, TDH, and related collection metrics.",
+        "The docs cover two-address and three-address patterns, plus a four-address scenario where an old hot wallet was compromised and cards moved through temporary, vault, and new minting wallets.",
+        "Each address generally needs reciprocal consolidation records with the other addresses it should be grouped with."
+      ],
+      "canonical_path": "/delegation/consolidation-use-cases",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/register-consolidation",
+        "/delegation/delegation-faq",
+        "/consolidation-mapping-tool"
+      ],
+      "tags": ["delegation", "consolidation", "wallet", "tdh"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/consolidation-use-cases.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address-del-manager.html"
+      ]
+    },
+    {
+      "id": "delegation.faq",
+      "kind": "route",
+      "title": "Delegation FAQ",
+      "aliases": [
+        "delegation faq",
+        "delegation how to",
+        "delegation docs",
+        "delegation help",
+        "delegation guide",
+        "consolidation faq",
+        "wallet delegation faq"
+      ],
+      "keywords": [
+        "delegation",
+        "faq",
+        "how",
+        "register",
+        "view",
+        "manage",
+        "revoke",
+        "lock",
+        "unlock",
+        "safe",
+        "usecase"
+      ],
+      "facts": [
+        "The Delegation FAQ lives at /delegation/delegation-faq.",
+        "It indexes how-to articles for registering delegations, delegation managers, consolidations, SAFE transaction-builder flows, supported use cases, viewing records, updating, revoking, locking, and unlocking wallets.",
+        "Use it when users ask broad Delegation Center how-to questions or ask where the delegation docs live."
+      ],
+      "canonical_path": "/delegation/delegation-faq",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases"
+      ],
+      "tags": ["delegation", "faq", "docs"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/delegation-faq.html",
+        "components/delegation/html/delegationContent.ts"
+      ]
+    },
+    {
+      "id": "delegation.register-delegation-doc",
+      "kind": "workflow",
+      "title": "How to Register a Delegation",
+      "aliases": [
+        "how to register a delegation",
+        "register delegation docs",
+        "register delegation faq",
+        "delegate a wallet",
+        "delegate hot wallet",
+        "delegate minting wallet"
+      ],
+      "keywords": [
+        "delegation",
+        "register",
+        "delegate",
+        "wallet",
+        "collection",
+        "expiry",
+        "token",
+        "utility"
+      ],
+      "facts": [
+        "The register-delegation help article lives at /delegation/delegation-faq/register-delegation.",
+        "To register a delegation, open Delegation Center, choose Register Delegation, choose the collection, enter the delegate wallet, select a use case such as #1 All, choose expiry and token scope, then submit and execute the transaction.",
+        "A delegation lets another wallet use NFT utility without moving the NFT from the delegator wallet."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-delegation",
+      "related_paths": [
+        "/delegation/register-delegation",
+        "/delegation/delegation-center",
+        "/delegation/wallet-architecture"
+      ],
+      "tags": ["delegation", "workflow", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-delegation.html"
+      ]
+    },
+    {
+      "id": "delegation.delegation-manager-doc",
+      "kind": "workflow",
+      "title": "Delegation Manager",
+      "aliases": [
+        "delegation manager",
+        "sub delegation",
+        "sub-delegation",
+        "register delegation manager",
+        "delegation management rights",
+        "manager wallet",
+        "use case 998"
+      ],
+      "keywords": [
+        "delegation",
+        "manager",
+        "sub",
+        "wallet",
+        "rights",
+        "998",
+        "register",
+        "maintain",
+        "consolidations"
+      ],
+      "facts": [
+        "The Delegation Manager help article lives at /delegation/delegation-faq/register-sub-delegation.",
+        "A delegation manager gives a manager wallet permission to maintain delegations and consolidations for another wallet.",
+        "The docs describe registering a manager from the vault wallet to a delegated wallet, then using that delegated wallet to register future delegations or consolidations."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-sub-delegation",
+      "related_paths": [
+        "/delegation/register-sub-delegation",
+        "/delegation/delegation-faq/register-delegation-using-sub-delegation",
+        "/delegation/delegation-faq/revoke-delegation-using-sub-delegation"
+      ],
+      "tags": ["delegation", "manager", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-sub-delegation.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-delegation-using-sub-delegation.html"
+      ]
+    },
+    {
+      "id": "delegation.safe-doc",
+      "kind": "workflow",
+      "title": "Delegate using SAFE",
+      "aliases": [
+        "delegate using safe",
+        "delegate using gnosis",
+        "safe transaction builder",
+        "gnosis transaction builder",
+        "safe wallet delegation",
+        "safe delegation manager"
+      ],
+      "keywords": [
+        "safe",
+        "gnosis",
+        "delegation",
+        "transaction",
+        "builder",
+        "manager",
+        "998",
+        "contract",
+        "abi"
+      ],
+      "facts": [
+        "The SAFE delegation help article lives at /delegation/delegation-faq/using-safe.",
+        "The docs show using the SAFE Transaction Builder with the NFTDelegation.com contract to register delegation manager rights.",
+        "The SAFE flow uses the Any Collection value, no-expiry value, use case 998 for Delegation Management, allTokens true, tokenId 0, then creates and sends the batch transaction."
+      ],
+      "canonical_path": "/delegation/delegation-faq/using-safe",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/delegation-faq/register-sub-delegation"
+      ],
+      "tags": ["delegation", "safe", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/using-safe.html"
       ]
     },
     {

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1315,14 +1315,20 @@
       ]
     },
     {
-      "id": "delegation.register-consolidation",
+      "id": "delegation.register-consolidation-doc",
       "kind": "workflow",
-      "title": "Register Consolidation",
-      "link_label": "Register Consolidation",
+      "title": "How to Register a Consolidation",
+      "link_label": "Register Consolidation Guide",
       "aliases": [
+        "how to register a consolidation",
+        "how do i register a consolidation",
+        "how do i set up a consolidation",
+        "set up consolidation",
+        "setup consolidation",
+        "register consolidation docs",
+        "register consolidation faq",
         "register consolidation",
         "register a consolidation",
-        "how do i register a consolidation",
         "wallet consolidation",
         "consolidate wallets",
         "tdh consolidation",
@@ -1341,16 +1347,57 @@
         "999"
       ],
       "facts": [
-        "Register Consolidation lives at /delegation/register-consolidation and can also be opened from the Delegation Center.",
-        "Use Register Consolidation to connect wallets you control for supported 6529 metrics such as TDH, total cards, and unique cards; it is consolidation use case #999.",
-        "The form requires a connected wallet, Collection, and Consolidating With address; for TDH consolidation, use Any Collection or The Memes.",
+        "A consolidation connects wallets you control so 6529 can treat them together for supported metrics such as TDH, total cards, and unique cards; it is consolidation use case #999.",
+        "To register a consolidation, open Register Consolidation from the Delegation Center, choose the collection, enter the Consolidating With address, submit, and execute the transaction.",
+        "For TDH consolidation, use Any Collection or The Memes.",
         "Consolidation should be reciprocal when two wallets are intended to be treated together, and it is not a delegation and does not grant rights."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-consolidation",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases",
+        "/delegation/register-consolidation"
+      ],
+      "tags": ["delegation", "consolidation", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-consolidation.html",
+        "ops/docs/delegation/flow-delegation-center-to-onchain-actions.md"
+      ]
+    },
+    {
+      "id": "delegation.register-consolidation",
+      "kind": "workflow",
+      "title": "Register Consolidation Form",
+      "link_label": "Register Consolidation",
+      "aliases": [
+        "register consolidation form",
+        "open register consolidation",
+        "where is register consolidation",
+        "register a consolidation form"
+      ],
+      "keywords": [
+        "consolidation",
+        "consolidate",
+        "register",
+        "wallet",
+        "wallets",
+        "tdh",
+        "primary",
+        "address",
+        "reciprocal",
+        "999"
+      ],
+      "facts": [
+        "The Register Consolidation form is the Delegation Center action for connecting wallets you control for supported 6529 metrics.",
+        "The form requires a connected wallet, Collection, and Consolidating With address.",
+        "For TDH consolidation, use Any Collection or The Memes."
       ],
       "canonical_path": "/delegation/register-consolidation",
       "related_paths": [
-        "/delegation/delegation-center",
-        "/delegation/wallet-checker",
+        "/delegation/delegation-faq/register-consolidation",
+        "/delegation/wallet-architecture",
         "/delegation/consolidation-use-cases",
+        "/delegation/delegation-center",
         "/delegation/assign-primary-address"
       ],
       "tags": ["delegation", "consolidation", "wallet"],
@@ -1368,6 +1415,12 @@
         "wallet architecture",
         "4 wallet architecture",
         "four wallet architecture",
+        "4 wallet consolidation",
+        "four wallet consolidation",
+        "4 wallet setup",
+        "four wallet setup",
+        "how do i set up 4 wallet consolidation",
+        "set up 4 wallet consolidation",
         "three address protocol",
         "tap",
         "vault wallet",
@@ -1393,17 +1446,17 @@
         "malware"
       ],
       "facts": [
-        "Wallet Architecture lives at /delegation/wallet-architecture and is part of the Delegation Center docs.",
         "The recommended architecture separates a vault wallet for long-term NFT storage, a transaction wallet for trusted marketplace activity, and a minting wallet for unknown or higher-risk minting activity.",
         "The docs call this the Three Address Protocol, or TAP, and explain how separate wallets reduce phishing, malware, and malicious-site risk.",
-        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet."
+        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet.",
+        "Use the consolidation docs and Register Consolidation form when you want those wallets treated together for supported 6529 metrics."
       ],
       "canonical_path": "/delegation/wallet-architecture",
       "related_paths": [
-        "/delegation/delegation-faq",
         "/delegation/consolidation-use-cases",
-        "/delegation/register-delegation",
-        "/delegation/register-consolidation"
+        "/delegation/delegation-faq/register-consolidation",
+        "/delegation/register-consolidation",
+        "/delegation/delegation-faq"
       ],
       "tags": ["delegation", "wallet", "security", "architecture"],
       "source_refs": [
@@ -1439,7 +1492,6 @@
         "reciprocal"
       ],
       "facts": [
-        "Consolidation Use Cases lives at /delegation/consolidation-use-cases.",
         "Consolidations help 6529 treat multiple wallets controlled by one collector together for metrics such as total cards, unique cards, TDH, and related collection metrics.",
         "The docs cover two-address and three-address patterns, plus a four-address scenario where an old hot wallet was compromised and cards moved through temporary, vault, and new minting wallets.",
         "Each address generally needs reciprocal consolidation records with the other addresses it should be grouped with."
@@ -1447,6 +1499,7 @@
       "canonical_path": "/delegation/consolidation-use-cases",
       "related_paths": [
         "/delegation/wallet-architecture",
+        "/delegation/delegation-faq/register-consolidation",
         "/delegation/register-consolidation",
         "/delegation/delegation-faq",
         "/consolidation-mapping-tool"
@@ -1485,7 +1538,6 @@
         "usecase"
       ],
       "facts": [
-        "The Delegation FAQ lives at /delegation/delegation-faq.",
         "It indexes how-to articles for registering delegations, delegation managers, consolidations, SAFE transaction-builder flows, supported use cases, viewing records, updating, revoking, locking, and unlocking wallets.",
         "Use it when users ask broad Delegation Center how-to questions or ask where the delegation docs live."
       ],
@@ -1499,6 +1551,91 @@
       "source_refs": [
         "public/delegation-content/delegation-docs-2026-06-16/html/delegation-faq.html",
         "components/delegation/html/delegationContent.ts"
+      ]
+    },
+    {
+      "id": "delegation.manage-revoke-doc",
+      "kind": "workflow",
+      "title": "How to Revoke a Delegation",
+      "link_label": "Revoke Delegation",
+      "aliases": [
+        "how to revoke a delegation",
+        "how do i revoke a delegation",
+        "revoke delegation",
+        "remove delegation",
+        "cancel delegation",
+        "delete delegation",
+        "revoke a consolidation",
+        "revoke consolidation",
+        "revoke delegation manager"
+      ],
+      "keywords": [
+        "delegation",
+        "revoke",
+        "remove",
+        "cancel",
+        "delete",
+        "manager",
+        "consolidation",
+        "wallet",
+        "manage",
+        "view"
+      ],
+      "facts": [
+        "To revoke a delegation, delegation manager, or consolidation, open the Delegation Center and choose View/Manage for the relevant collection.",
+        "On the Manage/View Collection page, find the address or record you want to revoke and click Revoke.",
+        "Execute the transaction to remove the delegation, manager permission, or consolidation record."
+      ],
+      "canonical_path": "/delegation/delegation-faq/manage-revoke",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq",
+        "/delegation/delegation-faq/revoke-delegation-using-sub-delegation"
+      ],
+      "tags": ["delegation", "workflow", "faq", "revoke"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/manage-revoke.html"
+      ]
+    },
+    {
+      "id": "delegation.manage-update-doc",
+      "kind": "workflow",
+      "title": "How to Update a Delegation",
+      "link_label": "Update Delegation",
+      "aliases": [
+        "how to update a delegation",
+        "how do i update a delegation",
+        "update delegation",
+        "edit delegation",
+        "change delegation",
+        "update consolidation",
+        "update delegation manager"
+      ],
+      "keywords": [
+        "delegation",
+        "update",
+        "edit",
+        "change",
+        "manager",
+        "consolidation",
+        "expiry",
+        "token",
+        "wallet",
+        "manage"
+      ],
+      "facts": [
+        "To update a delegation, delegation manager, or consolidation, open View/Manage in the Delegation Center for the relevant collection.",
+        "Find the address or record you want to update, click Update, adjust the delegated wallet, expiry, or token scope, then submit.",
+        "Execute the transaction to apply the update."
+      ],
+      "canonical_path": "/delegation/delegation-faq/manage-update",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq"
+      ],
+      "tags": ["delegation", "workflow", "faq", "update"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/manage-update.html"
       ]
     },
     {
@@ -1524,7 +1661,6 @@
         "utility"
       ],
       "facts": [
-        "The register-delegation help article lives at /delegation/delegation-faq/register-delegation.",
         "To register a delegation, open Delegation Center, choose Register Delegation, choose the collection, enter the delegate wallet, select a use case such as #1 All, choose expiry and token scope, then submit and execute the transaction.",
         "A delegation lets another wallet use NFT utility without moving the NFT from the delegator wallet."
       ],
@@ -1564,7 +1700,6 @@
         "consolidations"
       ],
       "facts": [
-        "The Delegation Manager help article lives at /delegation/delegation-faq/register-sub-delegation.",
         "A delegation manager gives a manager wallet permission to maintain delegations and consolidations for another wallet.",
         "The docs describe registering a manager from the vault wallet to a delegated wallet, then using that delegated wallet to register future delegations or consolidations."
       ],
@@ -1604,7 +1739,6 @@
         "abi"
       ],
       "facts": [
-        "The SAFE delegation help article lives at /delegation/delegation-faq/using-safe.",
         "The docs show using the SAFE Transaction Builder with the NFTDelegation.com contract to register delegation manager rights.",
         "The SAFE flow uses the Any Collection value, no-expiry value, use case 998 for Delegation Management, allTokens true, tokenId 0, then creates and sends the batch transaction."
       ],

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -82,6 +82,265 @@
       "source_refs": ["components/about/AboutFAQ.tsx"]
     },
     {
+      "id": "about.nakamoto-threshold",
+      "kind": "route",
+      "title": "Nakamoto Threshold",
+      "aliases": [
+        "nakamoto threshold",
+        "naka threshold",
+        "what is the nakamoto threshold",
+        "card 4 lowest edition",
+        "meme card 4 edition count",
+        "lowest edition meme card",
+        "300 edition threshold",
+        "the memes threshold"
+      ],
+      "keywords": [
+        "nakamoto",
+        "threshold",
+        "naka",
+        "meme",
+        "memes",
+        "card",
+        "edition",
+        "300",
+        "lowest",
+        "cc0"
+      ],
+      "facts": [
+        "The Nakamoto Threshold page lives at /about/nakamoto-threshold.",
+        "Meme Card #4 is an homage to the first Rare Pepe and has an edition count of 300.",
+        "The Nakamoto Threshold is the commitment that Meme Card #4 remains the lowest-edition Meme Card, so other Meme Cards should exceed 300 editions.",
+        "The page frames the Nakamoto Threshold and CC0 as fixed commitments for The Memes."
+      ],
+      "canonical_path": "/about/nakamoto-threshold",
+      "related_paths": ["/about/the-memes", "/the-memes", "/about/license"],
+      "tags": ["about", "memes", "nakamoto-threshold"],
+      "source_refs": ["components/about/AboutNakamotoThreshold.tsx"]
+    },
+    {
+      "id": "about.data-decentralization",
+      "kind": "route",
+      "title": "Data Decentralization",
+      "aliases": [
+        "data decentralization",
+        "decentralized data",
+        "6529 data sources",
+        "where does 6529 data come from",
+        "can i replicate 6529 data",
+        "open data sources",
+        "public data"
+      ],
+      "keywords": [
+        "data",
+        "decentralization",
+        "decentralized",
+        "on-chain",
+        "ethereum",
+        "arweave",
+        "opensea",
+        "open",
+        "csv",
+        "tdh"
+      ],
+      "facts": [
+        "The Data Decentralization page lives at /about/data-decentralization.",
+        "6529's goal is to demonstrate how applications can be built in a decentralized manner.",
+        "The page explains that effectively all information on 6529.io comes from on-chain or public sources, or is derived transparently from those sources.",
+        "Listed data sources include Ethereum, Arweave decentralized storage, OpenSea API data, internal team-address records, computed thumbnails and TDH values, and compiled daily data exports.",
+        "The page points users to /open-data for daily compiled CSV exports."
+      ],
+      "canonical_path": "/about/data-decentralization",
+      "related_paths": ["/open-data", "/about/faq"],
+      "tags": ["about", "open-data", "decentralization"],
+      "source_refs": ["components/about/AboutDataDecentral.tsx"]
+    },
+    {
+      "id": "about.minting-meme-cards",
+      "kind": "route",
+      "title": "Minting Meme Cards",
+      "aliases": [
+        "minting meme cards",
+        "meme card minting",
+        "how do memes mint",
+        "where do memes mint",
+        "memes mint schedule",
+        "memes mint price",
+        "allowlist minting"
+      ],
+      "keywords": [
+        "minting",
+        "mint",
+        "meme",
+        "memes",
+        "allowlist",
+        "price",
+        "schedule",
+        "primary",
+        "sale"
+      ],
+      "facts": [
+        "The Minting Meme Cards page lives at /about/minting.",
+        "The Memes minting website is /the-memes/mint; there is no other official minting website for The Memes.",
+        "The page says Meme Cards are minted when the art for the next Meme Card is ready, currently about three times per week, though frequency and timing can vary.",
+        "The page says The Memes generally use an allowlist model to avoid gas wars and bot wars and to give a broad range of people a chance to mint.",
+        "Users should follow @6529collections for current mint dates and times."
+      ],
+      "canonical_path": "/about/minting",
+      "related_paths": ["/the-memes/mint", "/the-memes", "/about/the-memes"],
+      "tags": ["about", "memes", "minting"],
+      "source_refs": ["components/about/AboutMinting.tsx"]
+    },
+    {
+      "id": "about.license",
+      "kind": "route",
+      "title": "6529 License",
+      "aliases": [
+        "license",
+        "6529 license",
+        "memes license",
+        "meme lab license",
+        "gradient license",
+        "cc0",
+        "can i use meme card art",
+        "can i use gradient art"
+      ],
+      "keywords": [
+        "license",
+        "cc0",
+        "copyright",
+        "memes",
+        "meme",
+        "lab",
+        "gradient",
+        "commercial",
+        "derivative",
+        "rememes"
+      ],
+      "facts": [
+        "The License page lives at /about/license.",
+        "The Memes and Meme Lab NFTs are released by the artists under a Creative Commons 0 public-domain license to the maximum extent allowed by law.",
+        "The page says people can use The Memes and Meme Lab art for commercial or non-commercial purposes without seeking permission from the artists, subject to rights the artists do not control.",
+        "Gradient NFTs are treated differently: they have not been released under CC0, and the page warns against uses that could confuse people into thinking a product or service is offered by 6529."
+      ],
+      "canonical_path": "/about/license",
+      "related_paths": ["/about/the-memes", "/about/meme-lab", "/about/6529-gradient"],
+      "tags": ["about", "license", "cc0"],
+      "source_refs": ["components/about/AboutLicense.tsx"]
+    },
+    {
+      "id": "about.gdrc1",
+      "kind": "route",
+      "title": "Global Digital Rights Charter",
+      "aliases": [
+        "gdrc1",
+        "gdrc 1",
+        "global digital rights charter",
+        "digital rights charter"
+      ],
+      "keywords": ["gdrc1", "gdrc", "charter", "digital", "rights", "about"],
+      "facts": [
+        "The GDRC1 page lives at /about/gdrc1.",
+        "The page states that 6529 supports the Global Digital Rights Charter 1.",
+        "The page links to digitalrightscharter.org and displays the full text of GDRC1."
+      ],
+      "canonical_path": "/about/gdrc1",
+      "related_paths": ["/about/faq"],
+      "tags": ["about", "rights", "gdrc1"],
+      "source_refs": ["components/about/AboutGDRC1.tsx"]
+    },
+    {
+      "id": "about.nft-delegation",
+      "kind": "route",
+      "title": "NFT Delegation",
+      "aliases": [
+        "nft delegation",
+        "about nft delegation",
+        "delegation about page",
+        "where do i start delegation"
+      ],
+      "keywords": ["nft", "delegation", "delegate", "wallet", "center", "about"],
+      "facts": [
+        "The NFT Delegation about page lives at /about/nft-delegation.",
+        "The page sends users to the Delegation Center to get started with delegation."
+      ],
+      "canonical_path": "/about/nft-delegation",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq"
+      ],
+      "tags": ["about", "delegation"],
+      "source_refs": ["components/about/AboutNFTDelegation.tsx"]
+    },
+    {
+      "id": "about.ens",
+      "kind": "route",
+      "title": "ENS",
+      "aliases": [
+        "ens",
+        "ens domain",
+        "ens name",
+        "register ens",
+        "set primary ens",
+        "create ens subdomain",
+        "primary name"
+      ],
+      "keywords": [
+        "ens",
+        "domain",
+        "name",
+        "primary",
+        "subdomain",
+        "subname",
+        "ethereum"
+      ],
+      "facts": [
+        "The ENS page lives at /about/ens.",
+        "The page explains how to register an ENS domain name through ens.domains.",
+        "The page explains how to set an ENS primary name and how to create a subdomain."
+      ],
+      "canonical_path": "/about/ens",
+      "related_paths": ["/about/primary-address", "/{user}/identity"],
+      "tags": ["about", "ens", "identity"],
+      "source_refs": ["public/ens.html", "components/about/AboutHTML.tsx"]
+    },
+    {
+      "id": "about.tech-updates",
+      "kind": "route",
+      "title": "Tech Updates",
+      "aliases": [
+        "tech updates",
+        "about tech",
+        "technical updates",
+        "repo updates",
+        "build reports",
+        "wallet authentication upgrade"
+      ],
+      "keywords": [
+        "tech",
+        "updates",
+        "repo",
+        "reports",
+        "bot",
+        "release",
+        "wallet",
+        "authentication"
+      ],
+      "facts": [
+        "The Tech Updates page lives at /about/tech.",
+        "It is a longer-form area for 6529 tech updates, repo work, bot notes, release context, and build reports.",
+        "Shorter live repo activity still belongs in Follow The Repo.",
+        "The page links active technical notes such as the wallet authentication upgrade and indexes longer tech reports."
+      ],
+      "canonical_path": "/about/tech",
+      "related_paths": [
+        "/about/tech/wallet-authentication",
+        "/about/faq"
+      ],
+      "tags": ["about", "tech", "reports"],
+      "source_refs": ["components/about/tech/AboutTech.tsx"]
+    },
+    {
       "id": "navigation.search",
       "kind": "ui_affordance",
       "title": "Header search",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-19T00:00:00.000Z",
-  "commit_sha": "frontend-owned-curated-v1",
+  "generated_at": "2026-06-29T09:23:18.000Z",
+  "commit_sha": "01a39b18db2f",
   "base_url": "https://6529.io",
   "records": [
     {
@@ -51,9 +51,6 @@
       "kind": "route",
       "title": "6529 FAQ",
       "aliases": [
-        "faq",
-        "6529",
-        "6529.io",
         "6529 faq",
         "what is 6529.io",
         "about faq",
@@ -764,7 +761,7 @@
         "what is x tdh",
         "xtdh grants",
         "xTDH grants",
-        "grants"
+        "xTDH grant allocations"
       ],
       "keywords": [
         "xtdh",
@@ -1642,7 +1639,8 @@
         "how do i set up 4 wallet consolidation",
         "set up 4 wallet consolidation",
         "three address protocol",
-        "tap",
+        "what is tap",
+        "tap wallet architecture",
         "vault wallet",
         "transaction wallet",
         "minting wallet",

--- a/ops/skills/6529-agent-login/SKILL.md
+++ b/ops/skills/6529-agent-login/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: 6529-agent-login
+description: Manage local 6529 browser-agent test logins for this repo without committing wallet secrets. Use when Codex needs to claim or create a local test wallet, log a local 6529 dev-server browser session in or out, switch between seeded QA accounts, or inject 6529 wallet auth state for Playwright, Chrome, or the Codex in-app Browser.
+---
+
+# 6529 Agent Login
+
+## Overview
+
+Use this skill to log browser agents into a local 6529 frontend without adding
+wallet code to the app. The helper script keeps test wallet keys outside the
+repo by default, performs the normal session-v2 API login, and emits either a
+Playwright storage-state file, browser JavaScript, or a JSON payload for the
+development-only `/tools/agent-login` bridge route.
+
+Do not use this for production accounts unless the user explicitly provides a
+dedicated test key. Do not commit account pool files, private keys, emitted JSON
+payloads, storage-state files, cookies, access tokens, or generated login
+scripts.
+
+If the configured API endpoint is production and the QA task will create
+profiles, direct messages, drops, or other persistent data, get explicit user
+confirmation before performing those browser actions.
+
+## Helper
+
+From the repository root, use:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs <command>
+```
+
+The helper defaults to:
+
+- account pool: `~/.codex/6529-agent-login/accounts.json`
+- repo env source: current working directory, or `--repo /path/to/6529seize-frontend`
+- API endpoint: `API_ENDPOINT` from repo `.env`, or `--api https://...`
+- local browser origin for storage-state output: `BASE_ENDPOINT`, or `http://localhost:3001`
+
+The helper resolves `ethers` from the repo's `node_modules`; pass `--repo` when
+running outside the frontend repo.
+
+Use `--state /path/to/accounts.json` only for a developer-local account pool.
+Never point `--state` at a tracked file.
+
+## Account Pool
+
+Use `accounts.example.json` as a shape reference only. Do not fill that file, or
+any other tracked file under `ops/`, with real private keys.
+
+List accounts:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs list
+```
+
+Create a throwaway wallet:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs create --id agent-a --label "Agent A"
+```
+
+Import a seeded test account:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs import --id seeded-a --private-key 0x...
+```
+
+Claim an account for one thread:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs claim --client-id thread-a --id seeded-a
+```
+
+Use a stable `--client-id` per Codex thread. This makes parallel threads avoid
+claiming the same account.
+
+## Browser Login
+
+Start or locate a local 6529 dev server first. Then run:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --base-url http://localhost:3001 \
+  --format storage-state \
+  > /tmp/6529-agent-storage-state.json
+```
+
+Use that file as a Playwright browser context storage state. It writes:
+
+- `wallet-auth` cookie
+- `6529-wallet-accounts`
+- `6529-wallet-active-address`
+- `6529-wallet-address`
+- `6529-agent-login-active-address`
+- role keys when present
+
+It follows the storage shape used by `services/auth/auth.utils.ts`.
+
+For an already-open browser page that supports page JavaScript with real
+`localStorage` and `document.cookie`, emit a script instead:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --format browser-script \
+  > /tmp/6529-agent-login.js
+```
+
+Evaluate the generated script in the page and reload. This works with normal
+Playwright or Chrome automation contexts that expose browser storage APIs.
+
+## Codex In-App Browser Login
+
+The Codex in-app Browser cannot directly evaluate scripts that write
+`localStorage` and `document.cookie`. When the local repo includes the
+development-only bridge route, use `http://localhost:3001/tools/agent-login`
+instead.
+
+Generate a JSON payload:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --format json \
+  > /tmp/6529-agent-login.json
+```
+
+Open `/tools/agent-login` in the in-app Browser, paste the JSON into the
+`Login payload` textarea, and click `Apply`. The page writes the same wallet
+auth cookie and localStorage keys as the helper's browser script, marks the
+active account as agent-owned for the local bridge, then redirects home. Return
+to `/tools/agent-login` to see the active short wallet address or click
+`Logout`.
+
+Throwaway wallets authenticate but may not have a 6529 profile or role, so some
+profile-only UI can still ask for setup or signing. Use seeded accounts with
+profiles for normal logged-in product QA.
+
+For production or staging 6529 APIs, the helper automatically sends the
+first-party `Origin` header required by wallet auth. Override with `--origin`
+only when a different API requires it.
+
+## Logout
+
+Generate and evaluate a logout script, then reload:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs logout \
+  --format browser-script \
+  > /tmp/6529-agent-logout.js
+```
+
+For the in-app Browser, open `/tools/agent-login` and click `Logout`.
+
+## Switching Accounts
+
+Switch by logging in with another claimed account and evaluating the new browser
+script:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-b \
+  --format browser-script \
+  > /tmp/6529-agent-login.js
+```
+
+Reload after injection so React Query and auth providers restart from the new
+active wallet state.
+
+## Local Secret Storage
+
+The shared skill and helper live in the repo. Wallet material does not.
+
+Preferred local account pool for real local test wallet keys:
+
+```text
+~/.codex/6529-agent-login/accounts.json
+```
+
+This path survives worktree changes and branch switches while staying outside
+Git. It is the default for the helper and should be used for seeded local QA
+wallet pools.
+
+If a developer intentionally chooses repo-associated local state, prefer:
+
+```text
+.codex/6529-agent-login/accounts.json
+```
+
+That path is ignored by Git and follows the repo's local agent-state convention.
+Avoid putting real wallet keys under `ops/skills/6529-agent-login/`; the
+repo-local ignores there are a last line of defense for accidental outputs, not
+the preferred storage location.
+
+## Validation
+
+For skill or helper changes, use focused checks:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs help
+node ops/skills/6529-agent-login/scripts/agent-login.mjs list
+git status --short
+```
+
+Before closing a login QA task, confirm no wallet material or emitted auth
+payloads were added to tracked files.
+
+Useful evidence to report:
+
+- account ids, short addresses, and handles used
+- browser route used for login or logout
+- local wallet-state path touched
+- visible UI proof of the authenticated account or action
+- repo dirty state and tracked-secret check result
+
+## Limits
+
+This bypasses the wallet connect modal. It is good for app QA after login. It is
+not a test of MetaMask, Reown/AppKit wallet selection, or signature modal UX.
+It is also not a shortcut for creating messages, drops, profiles, or other app
+data directly through APIs when the task requires real UI coverage.

--- a/ops/skills/6529-agent-login/accounts.example.json
+++ b/ops/skills/6529-agent-login/accounts.example.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "accounts": [
+    {
+      "id": "seeded-a",
+      "label": "Seeded QA A",
+      "address": "0x0000000000000000000000000000000000000000",
+      "privateKey": "0xREPLACE_WITH_DEDICATED_TEST_PRIVATE_KEY",
+      "capabilities": [],
+      "profileHandle": "optional-profile-handle",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "leases": []
+}

--- a/ops/skills/6529-agent-login/agents/openai.yaml
+++ b/ops/skills/6529-agent-login/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "6529 Agent Login"
+  short_description: "Manage local 6529 test-wallet browser logins without committing wallet secrets."
+  default_prompt: "Use $6529-agent-login to log a local browser agent into 6529 with a test wallet."

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -1,0 +1,856 @@
+#!/usr/bin/env node
+
+/* eslint-disable security/detect-non-literal-fs-filename -- This local-only skill CLI intentionally reads and writes user-selected account-state and env files. */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const DEFAULT_STATE_PATH = path.join(
+  os.homedir(),
+  ".codex",
+  "6529-agent-login",
+  "accounts.json"
+);
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const STATE_VERSION = 1;
+
+const STORAGE_KEYS = {
+  accounts: "6529-wallet-accounts",
+  activeAddress: "6529-wallet-active-address",
+  legacyAddress: "6529-wallet-address",
+  legacyRefreshToken: "6529-wallet-refresh-token",
+  legacyRole: "6529-wallet-role",
+  agentLoginActiveAddress: "6529-agent-login-active-address",
+  authCookie: "wallet-auth",
+};
+const FETCH_TIMEOUT_MS = 15_000;
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (!value.startsWith("--")) {
+      args._.push(value);
+      continue;
+    }
+    const key = value.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function sleepSync(ms) {
+  const buffer = new SharedArrayBuffer(4);
+  const view = new Int32Array(buffer);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function withStateLock(statePath, fn) {
+  const lockPath = `${statePath}.lock`;
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+
+  let locked = false;
+  const deadline = Date.now() + 5000;
+  while (!locked) {
+    try {
+      fs.writeFileSync(lockPath, String(process.pid), {
+        flag: "wx",
+        mode: 0o600,
+      });
+      locked = true;
+    } catch (error) {
+      if (error?.code !== "EEXIST" || Date.now() > deadline) {
+        throw error;
+      }
+      sleepSync(50);
+    }
+  }
+
+  try {
+    const state = loadState(statePath);
+    pruneExpiredLeases(state);
+    const result = fn(state);
+    saveState(statePath, state);
+    return result;
+  } finally {
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {}
+  }
+}
+
+function emptyState() {
+  return {
+    version: STATE_VERSION,
+    accounts: [],
+    leases: [],
+  };
+}
+
+function loadState(statePath) {
+  if (!fs.existsSync(statePath)) {
+    return emptyState();
+  }
+  const parsed = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  if (parsed.version !== STATE_VERSION) {
+    throw new Error(`Unsupported account pool version: ${parsed.version}`);
+  }
+  if (!Array.isArray(parsed.accounts) || !Array.isArray(parsed.leases)) {
+    throw new TypeError("Invalid account pool file");
+  }
+  return parsed;
+}
+
+function saveState(statePath, state) {
+  const tempPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.renameSync(tempPath, statePath);
+  try {
+    fs.chmodSync(statePath, 0o600);
+  } catch {}
+}
+
+function normalizeId(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function randomId(prefix = "agent") {
+  return `${prefix}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+function normalizeCapabilities(value) {
+  let values = [];
+  if (Array.isArray(value)) {
+    values = value;
+  } else if (value) {
+    values = [value];
+  }
+  return Array.from(
+    new Set(
+      values
+        .map((capability) => String(capability || "").trim())
+        .filter(Boolean)
+    )
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+function parseEnvFile(filePath, target) {
+  if (!fs.existsSync(filePath)) return;
+  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^([A-Za-z_]\w*)=(.*)$/);
+    if (!match) continue;
+    const key = match[1];
+    if (target[key] !== undefined) continue;
+    let value = match[2] ?? "";
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    target[key] = value.replaceAll(String.raw`\n`, "\n");
+  }
+}
+
+function loadRepoEnv(repoRoot) {
+  const env = { ...process.env };
+  const nodeEnv = env.NODE_ENV || "development";
+  parseEnvFile(path.join(repoRoot, `.env.${nodeEnv}`), env);
+  parseEnvFile(path.join(repoRoot, ".env"), env);
+  return env;
+}
+
+function resolveRepoRoot(args) {
+  return path.resolve(String(args.repo || process.cwd()));
+}
+
+function loadEthers(repoRoot) {
+  const requireFromRepo = createRequire(path.join(repoRoot, "package.json"));
+  return requireFromRepo("ethers");
+}
+
+function redactSecretText(value) {
+  return String(value)
+    .replace(/\b0x[a-fA-F0-9]{64,}\b/g, "0x[redacted]")
+    .replace(
+      /\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g,
+      "[redacted-jwt]"
+    )
+    .replace(
+      /(access[_-]?token|refresh[_-]?token)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /(jwt|authorization)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /(private[_-]?key)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /((?:client|server)[_-]?signature)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    );
+}
+
+function normalizeApiBase(value) {
+  if (!value) {
+    throw new Error("Missing API endpoint. Pass --api or set API_ENDPOINT.");
+  }
+  let withoutSlash = String(value);
+  while (withoutSlash.endsWith("/")) {
+    withoutSlash = withoutSlash.slice(0, -1);
+  }
+  return withoutSlash.endsWith("/api") ? withoutSlash : `${withoutSlash}/api`;
+}
+
+function is6529Host(hostname) {
+  return hostname === "6529.io" || hostname.endsWith(".6529.io");
+}
+
+function inferFirstPartyOrigin(apiEndpoint) {
+  try {
+    const hostname = new URL(String(apiEndpoint)).hostname;
+    if (!is6529Host(hostname)) {
+      return null;
+    }
+    if (hostname.split(".").includes("staging")) {
+      return "https://staging.6529.io";
+    }
+    return "https://6529.io";
+  } catch {}
+  return null;
+}
+
+function accountForOutput(account, state) {
+  const lease = state.leases.find((entry) => entry.accountId === account.id);
+  return {
+    id: account.id,
+    label: account.label,
+    address: account.address,
+    capabilities: account.capabilities || [],
+    profileHandle: account.profileHandle || null,
+    createdAt: account.createdAt,
+    lease: lease
+      ? {
+          clientId: lease.clientId,
+          claimedAt: lease.claimedAt,
+          expiresAt: lease.expiresAt,
+        }
+      : null,
+  };
+}
+
+function findAccount(state, { id, address }, ethers) {
+  if (id) {
+    return state.accounts.find((account) => account.id === id) || null;
+  }
+  if (address) {
+    const checksummed = ethers.getAddress(address);
+    return (
+      state.accounts.find(
+        (account) => ethers.getAddress(account.address) === checksummed
+      ) || null
+    );
+  }
+  return null;
+}
+
+function addAccount(state, params, ethers) {
+  const wallet = params.privateKey
+    ? new ethers.Wallet(params.privateKey)
+    : ethers.Wallet.createRandom();
+  const id =
+    normalizeId(params.id) || randomId(params.privateKey ? "seeded" : "agent");
+  if (state.accounts.some((account) => account.id === id)) {
+    throw new Error(`Account id already exists: ${id}`);
+  }
+  const address = ethers.getAddress(wallet.address);
+  if (
+    state.accounts.some(
+      (account) => ethers.getAddress(account.address) === address
+    )
+  ) {
+    throw new Error(`Account address already exists: ${address}`);
+  }
+
+  const account = {
+    id,
+    label: String(params.label || id),
+    address,
+    privateKey: wallet.privateKey,
+    capabilities: normalizeCapabilities(params.capabilities),
+    profileHandle: params.profileHandle ? String(params.profileHandle) : null,
+    createdAt: new Date().toISOString(),
+  };
+  state.accounts.push(account);
+  return account;
+}
+
+function accountMatchesCapabilities(account, requestedCapabilities) {
+  if (requestedCapabilities.length === 0) return true;
+  const accountCapabilities = new Set(account.capabilities || []);
+  return requestedCapabilities.every((capability) =>
+    accountCapabilities.has(capability)
+  );
+}
+
+function pruneExpiredLeases(state) {
+  const now = Date.now();
+  state.leases = state.leases.filter((lease) => lease.expiresAt > now);
+}
+
+function claimAccount(state, params, ethers) {
+  const clientId = requireString(params.clientId, "client-id");
+  const requestedCapabilities = normalizeCapabilities(params.capabilities);
+  let account = findAccount(state, params, ethers);
+
+  if (!account) {
+    const existingLease = state.leases.find(
+      (lease) => lease.clientId === clientId
+    );
+    account = existingLease
+      ? state.accounts.find(
+          (candidate) =>
+            candidate.id === existingLease.accountId &&
+            accountMatchesCapabilities(candidate, requestedCapabilities)
+        ) || null
+      : null;
+  }
+
+  if (!account) {
+    account =
+      state.accounts.find((candidate) => {
+        if (!accountMatchesCapabilities(candidate, requestedCapabilities)) {
+          return false;
+        }
+        const lease = state.leases.find(
+          (entry) => entry.accountId === candidate.id
+        );
+        return !lease || lease.clientId === clientId;
+      }) || null;
+  }
+
+  if (!account && params.createIfNeeded !== false) {
+    account = addAccount(
+      state,
+      {
+        id: params.id,
+        label: params.label || `Auto ${clientId}`,
+        capabilities: requestedCapabilities,
+        profileHandle: params.profileHandle,
+      },
+      ethers
+    );
+  }
+
+  if (!account) {
+    throw new Error("No available account matches this claim");
+  }
+
+  const existingAccountLease = state.leases.find(
+    (lease) => lease.accountId === account.id
+  );
+  if (existingAccountLease && existingAccountLease.clientId !== clientId) {
+    throw new Error(
+      `Account ${account.id} is leased to ${existingAccountLease.clientId}`
+    );
+  }
+
+  const ttlMs = Number.isFinite(Number(params.ttlMs))
+    ? Math.max(10_000, Math.min(Number(params.ttlMs), 24 * 60 * 60 * 1000))
+    : DEFAULT_TTL_MS;
+  const now = Date.now();
+  state.leases = state.leases.filter((lease) => lease.accountId !== account.id);
+  state.leases.push({
+    accountId: account.id,
+    clientId,
+    claimedAt: now,
+    expiresAt: now + ttlMs,
+  });
+  return account;
+}
+
+function releaseAccount(state, params, ethers) {
+  const clientId = requireString(params.clientId, "client-id");
+  const account = findAccount(state, params, ethers);
+  const before = state.leases.length;
+  state.leases = state.leases.filter((lease) => {
+    if (lease.clientId !== clientId) return true;
+    if (!account) return false;
+    return lease.accountId !== account.id;
+  });
+  return before - state.leases.length;
+}
+
+function requireString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value.trim();
+}
+
+async function fetchJson(url, options) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    if (!response.ok) {
+      const message =
+        body && typeof body === "object"
+          ? body.error || body.message || JSON.stringify(body)
+          : body || response.statusText;
+      throw new Error(`API request failed (${response.status}): ${message}`);
+    }
+    return body;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildApiHeaders(env) {
+  return {
+    accept: "application/json",
+    ...(env.ORIGIN ? { origin: env.ORIGIN } : {}),
+    ...(env.STAGING_API_KEY ? { "x-6529-auth": env.STAGING_API_KEY } : {}),
+  };
+}
+
+async function loginWithAccount({ account, apiBase, env, role, ethers }) {
+  const wallet = new ethers.Wallet(account.privateKey);
+  const address = ethers.getAddress(wallet.address);
+  const nonceUrl = new URL(`${apiBase}/auth/session-nonce`);
+  nonceUrl.searchParams.set("signer_address", address);
+  nonceUrl.searchParams.set("client_type", "web");
+  nonceUrl.searchParams.set("chain_id", "1");
+
+  const nonce = await fetchJson(nonceUrl, {
+    method: "GET",
+    headers: buildApiHeaders(env),
+  });
+  if (!nonce?.signable_message || !nonce?.server_signature) {
+    throw new Error("Nonce response did not include signable_message");
+  }
+
+  const clientSignature = await wallet.signMessage(nonce.signable_message);
+  const loginBody = {
+    client_type: "web",
+    server_signature: nonce.server_signature,
+    client_signature: clientSignature,
+    client_address: address,
+    ...(role ? { role } : {}),
+  };
+  const session = await fetchJson(`${apiBase}/auth/session-login`, {
+    method: "POST",
+    headers: {
+      ...buildApiHeaders(env),
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(loginBody),
+  });
+  if (!session?.access_token) {
+    throw new Error("Login response did not include access_token");
+  }
+
+  return {
+    account: {
+      id: account.id,
+      label: account.label,
+      address,
+      profileHandle: account.profileHandle || null,
+    },
+    session: {
+      address: session.address || address,
+      role: session.role ?? null,
+      accessToken: session.access_token,
+      accessTokenExpiresAt: session.access_token_expires_at ?? null,
+      clientType: session.client_type ?? "web",
+    },
+  };
+}
+
+function buildLoginBrowserScript(payload) {
+  return `(() => {
+  const payload = ${JSON.stringify(payload)};
+  const account = {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.accounts)}, JSON.stringify([account]));
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.activeAddress)}, account.address);
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyAddress)}, account.address);
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.agentLoginActiveAddress)}, account.address);
+  localStorage.removeItem(${JSON.stringify(STORAGE_KEYS.legacyRefreshToken)});
+  if (account.role) {
+    localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyRole)}, account.role);
+    localStorage.setItem("auth-role-" + account.address.toLowerCase(), account.role);
+  } else {
+    localStorage.removeItem(${JSON.stringify(STORAGE_KEYS.legacyRole)});
+    localStorage.removeItem("auth-role-" + account.address.toLowerCase());
+  }
+  document.cookie = ${JSON.stringify(STORAGE_KEYS.authCookie)} + "=" + encodeURIComponent(account.jwt) + "; path=/; SameSite=Strict";
+  window.dispatchEvent(new CustomEvent("6529-wallet-accounts-updated"));
+  window.dispatchEvent(new CustomEvent("6529-auth-token-changed"));
+  window.dispatchEvent(new CustomEvent("6529-profile-switched"));
+  return {
+    ok: true,
+    address: account.address,
+    accountId: payload.account.id,
+  };
+})();`;
+}
+
+function buildStoredAccount(payload) {
+  return {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+}
+
+function buildLocalStorageEntries(payload) {
+  const account = buildStoredAccount(payload);
+  const entries = [
+    {
+      name: STORAGE_KEYS.accounts,
+      value: JSON.stringify([account]),
+    },
+    {
+      name: STORAGE_KEYS.activeAddress,
+      value: account.address,
+    },
+    {
+      name: STORAGE_KEYS.legacyAddress,
+      value: account.address,
+    },
+    {
+      name: STORAGE_KEYS.agentLoginActiveAddress,
+      value: account.address,
+    },
+  ];
+
+  if (account.role) {
+    entries.push(
+      {
+        name: STORAGE_KEYS.legacyRole,
+        value: account.role,
+      },
+      {
+        name: `auth-role-${account.address.toLowerCase()}`,
+        value: account.role,
+      }
+    );
+  }
+
+  return entries;
+}
+
+function normalizeOrigin(value) {
+  const url = new URL(String(value || "http://localhost:3001"));
+  return url.origin;
+}
+
+function getCookieExpires(payload) {
+  const expiresAt = Date.parse(
+    String(payload.session.accessTokenExpiresAt || "")
+  );
+  return Number.isFinite(expiresAt) ? Math.floor(expiresAt / 1000) : -1;
+}
+
+function buildPlaywrightStorageState(payload, baseUrl) {
+  const origin = normalizeOrigin(baseUrl);
+  const url = new URL(origin);
+  return {
+    cookies: [
+      {
+        name: STORAGE_KEYS.authCookie,
+        value: payload.session.accessToken,
+        domain: url.hostname,
+        path: "/",
+        expires: getCookieExpires(payload),
+        httpOnly: false,
+        secure: url.protocol === "https:",
+        sameSite: "Strict",
+      },
+    ],
+    origins: [
+      {
+        origin,
+        localStorage: buildLocalStorageEntries(payload),
+      },
+    ],
+  };
+}
+
+function buildLogoutBrowserScript() {
+  return `(() => {
+  const keys = ${JSON.stringify(Object.values(STORAGE_KEYS).filter((key) => key !== STORAGE_KEYS.authCookie))};
+  for (const key of keys) localStorage.removeItem(key);
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith("auth-role-")) localStorage.removeItem(key);
+  }
+  document.cookie = ${JSON.stringify(STORAGE_KEYS.authCookie)} + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict";
+  window.dispatchEvent(new CustomEvent("6529-wallet-accounts-updated"));
+  window.dispatchEvent(new CustomEvent("6529-auth-token-changed"));
+  window.dispatchEvent(new CustomEvent("6529-profile-switched"));
+  return { ok: true };
+})();`;
+}
+
+function writeOutput(value, format) {
+  if (format === "quiet") return;
+  if (format === "browser-script") {
+    process.stdout.write(`${value}\n`);
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const command = args._[0] || "help";
+  const format = String(args.format || "json");
+  const statePath = path.resolve(String(args.state || DEFAULT_STATE_PATH));
+
+  if (command === "help") {
+    writeOutput(
+      {
+        commands: [
+          "list",
+          "create",
+          "import",
+          "claim",
+          "release",
+          "login",
+          "logout",
+        ],
+        formats: [
+          "json",
+          "browser-script",
+          "storage-state",
+          "playwright-storage",
+          "quiet",
+        ],
+        statePath,
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "logout") {
+    writeOutput(
+      format === "browser-script" ? buildLogoutBrowserScript() : { ok: true },
+      format
+    );
+    return;
+  }
+
+  if (command === "list") {
+    const state = loadState(statePath);
+    pruneExpiredLeases(state);
+    writeOutput(
+      {
+        statePath,
+        accounts: state.accounts.map((account) =>
+          accountForOutput(account, state)
+        ),
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "create" || command === "import") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
+    const account = withStateLock(statePath, (state) =>
+      addAccount(
+        state,
+        {
+          id: args.id,
+          label: args.label,
+          privateKey:
+            command === "import"
+              ? requireString(args["private-key"], "private-key")
+              : undefined,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+        },
+        ethers
+      )
+    );
+    writeOutput(
+      {
+        account: {
+          id: account.id,
+          label: account.label,
+          address: account.address,
+        },
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "claim") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
+    let redacted;
+    withStateLock(statePath, (state) => {
+      const account = claimAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+          label: args.label,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+          createIfNeeded: args.create !== "false",
+          ttlMs: args.ttlMs,
+        },
+        ethers
+      );
+      redacted = accountForOutput(account, state);
+      return account;
+    });
+    writeOutput({ account: redacted }, format);
+    return;
+  }
+
+  if (command === "release") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
+    const released = withStateLock(statePath, (state) =>
+      releaseAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+        },
+        ethers
+      )
+    );
+    writeOutput({ released }, format);
+    return;
+  }
+
+  if (command === "login") {
+    const repoRoot = resolveRepoRoot(args);
+    const env = loadRepoEnv(repoRoot);
+    const ethers = loadEthers(repoRoot);
+    let account;
+    withStateLock(statePath, (state) => {
+      account = claimAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+          label: args.label,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+          createIfNeeded: args.create !== "false",
+          ttlMs: args.ttlMs,
+        },
+        ethers
+      );
+      return account;
+    });
+
+    const apiEndpoint = args.api || env.API_ENDPOINT;
+    const apiBase = normalizeApiBase(apiEndpoint);
+    const payload = await loginWithAccount({
+      account,
+      apiBase,
+      env: {
+        STAGING_API_KEY: args["staging-auth"] || env.STAGING_API_KEY,
+        ORIGIN:
+          args.origin ||
+          env.AGENT_LOGIN_ORIGIN ||
+          inferFirstPartyOrigin(apiEndpoint) ||
+          args["base-url"] ||
+          env.BASE_ENDPOINT,
+      },
+      role: args.role,
+      ethers,
+    });
+
+    let output = payload;
+    if (format === "browser-script") {
+      output = buildLoginBrowserScript(payload);
+    } else if (format === "storage-state" || format === "playwright-storage") {
+      output = buildPlaywrightStorageState(
+        payload,
+        args["base-url"] || env.BASE_ENDPOINT || "http://localhost:3001"
+      );
+    }
+    writeOutput(output, format);
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  if (error instanceof Error && error.name === "AbortError") {
+    console.error("Agent login command aborted.");
+  } else if (error instanceof Error) {
+    console.error(
+      `Agent login command failed: ${redactSecretText(error.message)}`
+    );
+  } else {
+    console.error("Agent login command failed.");
+  }
+  process.exitCode = 1;
+}

--- a/ops/skills/README.md
+++ b/ops/skills/README.md
@@ -6,6 +6,8 @@ This folder stores repo-local Codex skills and agent guidance.
 
 ## Repo-Local Skills
 
+- [6529 Agent Login](6529-agent-login/SKILL.md): manages local
+  browser-agent test wallet logins without committing wallet secrets.
 - [6529 Autonomous Manager](6529-autonomous-manager/SKILL.md): owns scoped
   6529 frontend workstreams from instruction to validated closeout.
 - [Commit Docs Updater](commit-docs-updater/SKILL.md):

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -52,9 +52,15 @@
       "title": "6529 FAQ",
       "aliases": [
         "faq",
+        "6529",
+        "6529.io",
         "6529 faq",
+        "what is 6529.io",
         "about faq",
         "what is 6529",
+        "what is 6529 trying to do",
+        "what is 6529 building",
+        "what is the goal of 6529",
         "how do i get started",
         "how does 6529 work",
         "what can i do on 6529"
@@ -69,17 +75,71 @@
         "memes",
         "tdh",
         "rep",
-        "nic"
+        "nic",
+        "network",
+        "state",
+        "coordination",
+        "public",
+        "goods"
       ],
       "facts": [
         "The 6529 FAQ lives at /about/faq.",
-        "The FAQ explains what 6529 is, how to get started, Waves, profiles, TDH, REP, NIC, The Memes, Meme drops, and related core product concepts.",
+        "6529 and 6529.io refer to the same product ecosystem in user questions.",
+        "6529 is building a decentralized network state: a permissionless global network society that funds, builds, and coordinates public-goods work across art, science, culture, and technology.",
+        "In product terms, 6529 is not only an NFT collection site; it is a coordination system built around wallet identity, profiles, The Memes, Meme Lab, Gradients, NextGen, Waves, voting, groups, delegation, REP/CIC reputation, TDH/xTDH network metrics, open data, minting/claims infrastructure, and help tooling such as @help6529.",
+        "The long-term goal is nation-scale positive impact.",
+        "The core idea is to extend what Bitcoin and Ethereum proved for money and code into human coordination itself, so communities can organize, allocate attention, vote, build, and distribute work permissionlessly.",
         "Use the FAQ when users ask broad getting-started questions or ask where general 6529 product explanations live."
       ],
       "canonical_path": "/about/faq",
       "related_paths": ["/", "/waves", "/network", "/about/the-memes"],
       "tags": ["about", "faq", "getting-started"],
       "source_refs": ["components/about/AboutFAQ.tsx"]
+    },
+    {
+      "id": "about.terms-of-service",
+      "kind": "route",
+      "title": "Terms of Service",
+      "aliases": [
+        "terms of service",
+        "terms",
+        "tos",
+        "6529 terms",
+        "6529 terms of service",
+        "platform terms",
+        "legal terms",
+        "what are terms of service"
+      ],
+      "keywords": [
+        "terms",
+        "service",
+        "legal",
+        "platform",
+        "privacy",
+        "copyright",
+        "liability",
+        "arbitration",
+        "sanctions",
+        "cc0"
+      ],
+      "facts": [
+        "The Terms of Service page lives at /about/terms-of-service.",
+        "The page defines the terms for using the 6529 platform and was last updated February 23, 2023.",
+        "The terms cover platform access, 6529 NFTs, incorporated about pages, privacy, copyright, delegation and consolidation, wallet responsibility, phishing, CC0, disclaimers, liability limits, arbitration, and related legal topics.",
+        "Use this page when users ask where the 6529 Terms of Service live or ask about the public legal terms for using 6529.io."
+      ],
+      "canonical_path": "/about/terms-of-service",
+      "related_paths": [
+        "/about/privacy-policy",
+        "/about/cookie-policy",
+        "/about/copyright",
+        "/dispute-resolution"
+      ],
+      "tags": ["about", "terms", "legal"],
+      "source_refs": [
+        "components/about/AboutTermsOfService.tsx",
+        "components/footer/Footer.tsx"
+      ]
     },
     {
       "id": "about.nakamoto-threshold",
@@ -595,22 +655,44 @@
         "total",
         "days",
         "held",
+        "raw",
         "boost",
         "boosted",
         "unboosted",
+        "edition",
+        "weighting",
         "metric",
         "rate",
-        "hodl"
+        "hodl",
+        "category",
+        "sets",
+        "leaderboard",
+        "levels"
       ],
       "facts": [
-        "TDH stands for Total Days Held.",
+        "TDH means Total Days Held.",
         "TDH does not stand for Total Dynamic Head.",
-        "TDH is a time-weighted NFT holding metric that starts from days held and applies edition-size weighting plus active boosters.",
-        "TDH updates on a daily cadence and is used across Network surfaces.",
-        "The Memes and other NFT surfaces can show a per-card TDH or HODL rate."
+        "TDH is 6529's time-weighted holding metric for eligible NFTs.",
+        "Conceptually, TDH measures long-term participation and skin in the 6529 ecosystem.",
+        "Each eligible NFT contributes value based on how long it has been held; that base holding time is then adjusted by edition-size weighting and by collection boosters.",
+        "The calculation has three layers: unweighted days, edition weighting, and boosts.",
+        "Unweighted days means each NFT contributes 1 unit per day it is held.",
+        "Edition weighting means days held are multiplied by a HODL or edition-size rate; on the frontend TDH page, FirstGM with edition size 3,941 is the 1.0 baseline.",
+        "Boosts multiply weighted TDH by active boosters based on what the holder owns.",
+        "The backend stores the distinctions separately: tdh__raw is raw full days held, tdh is raw days multiplied by HODL or edition weighting, and boosted_tdh is weighted TDH multiplied by the active boost.",
+        "Current TDH 1.4 rules use the higher of Category A or Category B boosters, plus Category C.",
+        "Category A is the complete Meme Card set boost, with diminishing additional-set boosts.",
+        "Category B covers season, genesis, and nakamoto set boosts.",
+        "Category C is the Gradient boost, up to 5 Gradients.",
+        "TDH is calculated daily at 00:00 UTC and is used throughout the network: profiles, leaderboards, Levels, groups, Network views, Waves voting and eligibility, and public data."
       ],
       "canonical_path": "/network/tdh",
-      "related_paths": ["/network/definitions", "/network/tdh/historic-boosts"],
+      "related_paths": [
+        "/network/definitions",
+        "/network/tdh/historic-boosts",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "tdh", "glossary"],
       "source_refs": [
         "ops/docs/network/feature-tdh-boost-rules.md",
@@ -645,7 +727,12 @@
         "For a single TDH explanation, point users to the TDH page."
       ],
       "canonical_path": "/network/definitions",
-      "related_paths": ["/network/tdh", "/network/levels"],
+      "related_paths": [
+        "/network/tdh",
+        "/network/tdh/historic-boosts",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "glossary"],
       "source_refs": ["ops/docs/network/feature-network-definitions.md"]
     },
@@ -669,19 +756,52 @@
       "id": "network.xtdh",
       "kind": "glossary",
       "title": "xTDH",
-      "aliases": ["xtdh", "x tdh", "extended tdh", "grants"],
+      "aliases": [
+        "xtdh",
+        "x tdh",
+        "extended tdh",
+        "what is xtdh",
+        "what is x tdh",
+        "xtdh grants",
+        "xTDH grants",
+        "grants"
+      ],
       "keywords": [
         "xtdh",
+        "tdh",
+        "extension",
+        "external",
+        "eligible",
+        "erc721",
+        "coefficient",
         "grants",
         "received",
         "granted",
+        "produced",
+        "allocation",
+        "tokens",
+        "collections",
         "network",
         "profile"
       ],
       "facts": [
-        "xTDH is an extended TDH-related surface with granted and received views on profiles.",
-        "Profile xTDH information is available under /{user}/xtdh when visible.",
-        "Network xTDH overview and formulas live under the Network area."
+        "xTDH is an extension of TDH that lets TDH-like network participation flow beyond core 6529 holders to other NFT holders and communities.",
+        "xTDH can be earned by holding eligible cards outside The Memes ecosystem.",
+        "The frontend /network/xtdh page describes xTDH as an extension of TDH that helps include other NFT holders in the 6529 ecosystem and offer them the benefits of TDH.",
+        "xTDH tracks how much xTDH your Memes produce, how much xTDH you receive from grants on tokens you own, and how much xTDH you have granted away.",
+        "Produced xTDH comes from TDH production: produced_xTDH_today = TDH gained today * xTDH_coefficient.",
+        "The current backend coefficient is 0.1.",
+        "Daily xTDH rate is xtdh_rate = produced_today - granted_out_today + received_today.",
+        "Total xTDH accumulates as xtdh_total = xtdh_total_previous + xtdh_rate.",
+        "The key idea is grants: a profile that produces xTDH can grant future xTDH flow to all tokens in an external ERC-721 collection or to a selected subset of tokens.",
+        "If you own a token with an active grant, you receive your share of that grant while you own the token.",
+        "Per-token grant flow is grant_amount_per_token = rate / denominator, where the denominator is either the collection total supply for full-collection grants or the number of selected tokens for partial grants.",
+        "Transfers inside the same consolidation group do not reset the ownership window; sales or transfers across groups do reset it.",
+        "The first grant increment requires the grant and token ownership to have matured past the required midnight or 24-hour windows.",
+        "xTDH is not simply TDH for external NFTs; it is a grant and allocation layer where TDH producers create xTDH, can grant future production outward, external token owners can receive it, and ungranted or ineligible flow remains with the grantor.",
+        "No produced xTDH is intended to disappear; it is allocated to someone.",
+        "The live xTDH allocations dashboard at /xtdh shows network-wide stats and lets users drill down through Collections, Tokens, Contributors, and Grant details.",
+        "Profile xTDH information is available under /{user}/xtdh when visible."
       ],
       "canonical_path": "/network/xtdh",
       "related_paths": ["/{user}/xtdh", "/network"],
@@ -709,9 +829,58 @@
         "A dedicated Network TDH health route exists under /network/health/network-tdh."
       ],
       "canonical_path": "/network/health",
-      "related_paths": ["/network/health/network-tdh"],
+      "related_paths": ["/network/health/network-tdh", "/network/tdh"],
       "tags": ["network", "health"],
       "source_refs": ["ops/docs/network/feature-health-dashboard.md"]
+    },
+    {
+      "id": "network.tdh-stats",
+      "kind": "route",
+      "title": "Network TDH stats",
+      "aliases": [
+        "network tdh stats",
+        "network stats",
+        "tdh stats",
+        "tdh history",
+        "tdh charts",
+        "global tdh history",
+        "network tdh health",
+        "network tdh chart",
+        "network tdh page"
+      ],
+      "keywords": [
+        "network",
+        "tdh",
+        "stats",
+        "history",
+        "charts",
+        "global",
+        "daily",
+        "change",
+        "checkpoint",
+        "health"
+      ],
+      "facts": [
+        "Network TDH stats live at /network/health/network-tdh.",
+        "The page shows global TDH history in a fixed 10-row view.",
+        "It includes summary values for Network TDH, Daily Change, and Daily % Change.",
+        "It includes checkpoint estimates for the next 250,000,000 TDH checkpoints.",
+        "It shows Total TDH, Net TDH Daily Change, Created TDH Daily Change, and Destroyed TDH Change charts.",
+        "Each chart has boosted, unboosted, and unweighted series.",
+        "Use Network TDH stats when users ask for TDH history, TDH charts, global TDH movement, or deeper Network TDH health information."
+      ],
+      "canonical_path": "/network/health/network-tdh",
+      "related_paths": [
+        "/network/tdh",
+        "/network/definitions",
+        "/network/tdh/historic-boosts",
+        "/network/health"
+      ],
+      "tags": ["network", "tdh", "stats", "health"],
+      "source_refs": [
+        "app/network/health/network-tdh/page.tsx",
+        "ops/docs/network/feature-network-stats.md"
+      ]
     },
     {
       "id": "network.activity",
@@ -1315,6 +1484,57 @@
       ]
     },
     {
+      "id": "delegation.wallet-checker",
+      "kind": "route",
+      "title": "Wallet Checker",
+      "aliases": [
+        "wallet checker",
+        "check wallet",
+        "check my wallet",
+        "check wallet architecture",
+        "check my wallet architecture",
+        "view delegations",
+        "view consolidations",
+        "view delegations and consolidations",
+        "check delegations",
+        "check consolidations",
+        "active delegations",
+        "active consolidations"
+      ],
+      "keywords": [
+        "wallet",
+        "checker",
+        "check",
+        "view",
+        "delegation",
+        "delegations",
+        "manager",
+        "consolidation",
+        "consolidations",
+        "architecture",
+        "address",
+        "ens"
+      ],
+      "facts": [
+        "Wallet Checker lives at /delegation/wallet-checker.",
+        "Wallet Checker is a read-only diagnostics page for one wallet.",
+        "It checks delegations, delegation managers, and consolidation relationships for an entered Ethereum address or .eth ENS.",
+        "It can show Delegations, Active Minting Delegation for The Memes, Delegation Managers, Consolidations, Active Consolidation, and Incomplete Consolidation.",
+        "Use Wallet Checker when users ask how to check or view active delegations, consolidations, delegation managers, or wallet-architecture-related setup for an address."
+      ],
+      "canonical_path": "/delegation/wallet-checker",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases",
+        "/delegation/delegation-center"
+      ],
+      "tags": ["delegation", "wallet", "checker", "diagnostics"],
+      "source_refs": [
+        "ops/docs/delegation/feature-wallet-checker.md",
+        "components/delegation/delegation-page-metadata.ts"
+      ]
+    },
+    {
       "id": "delegation.register-consolidation-doc",
       "kind": "workflow",
       "title": "How to Register a Consolidation",
@@ -1453,6 +1673,7 @@
       ],
       "canonical_path": "/delegation/wallet-architecture",
       "related_paths": [
+        "/delegation/wallet-checker",
         "/delegation/consolidation-use-cases",
         "/delegation/delegation-faq/register-consolidation",
         "/delegation/register-consolidation",
@@ -3790,7 +4011,12 @@
         "Use the main TDH page for the current TDH explanation."
       ],
       "canonical_path": "/network/tdh/historic-boosts",
-      "related_paths": ["/network/tdh"],
+      "related_paths": [
+        "/network/tdh",
+        "/network/definitions",
+        "/network/health/network-tdh",
+        "/network/levels"
+      ],
       "tags": ["network", "tdh", "historic"],
       "source_refs": [
         "app/network/tdh/historic-boosts/page.tsx",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -47,6 +47,41 @@
       ]
     },
     {
+      "id": "about.faq",
+      "kind": "route",
+      "title": "6529 FAQ",
+      "aliases": [
+        "faq",
+        "6529 faq",
+        "about faq",
+        "what is 6529",
+        "how do i get started",
+        "how does 6529 work",
+        "what can i do on 6529"
+      ],
+      "keywords": [
+        "faq",
+        "about",
+        "6529",
+        "started",
+        "profile",
+        "waves",
+        "memes",
+        "tdh",
+        "rep",
+        "nic"
+      ],
+      "facts": [
+        "The 6529 FAQ lives at /about/faq.",
+        "The FAQ explains what 6529 is, how to get started, Waves, profiles, TDH, REP, NIC, The Memes, Meme drops, and related core product concepts.",
+        "Use the FAQ when users ask broad getting-started questions or ask where general 6529 product explanations live."
+      ],
+      "canonical_path": "/about/faq",
+      "related_paths": ["/", "/waves", "/network", "/about/the-memes"],
+      "tags": ["about", "faq", "getting-started"],
+      "source_refs": ["components/about/AboutFAQ.tsx"]
+    },
+    {
       "id": "navigation.search",
       "kind": "ui_affordance",
       "title": "Header search",
@@ -1064,6 +1099,264 @@
         "ops/docs/delegation/feature-delegation-action-flows.md",
         "ops/docs/delegation/flow-delegation-center-to-onchain-actions.md",
         "ops/docs/delegation/source-of-truth-spec.md"
+      ]
+    },
+    {
+      "id": "delegation.wallet-architecture",
+      "kind": "workflow",
+      "title": "Wallet Architecture",
+      "aliases": [
+        "wallet architecture",
+        "4 wallet architecture",
+        "four wallet architecture",
+        "three address protocol",
+        "tap",
+        "vault wallet",
+        "transaction wallet",
+        "minting wallet",
+        "hot wallet",
+        "cold wallet",
+        "wallet setup",
+        "safe wallet architecture"
+      ],
+      "keywords": [
+        "wallet",
+        "architecture",
+        "vault",
+        "transaction",
+        "minting",
+        "hot",
+        "cold",
+        "safe",
+        "gnosis",
+        "tap",
+        "phishing",
+        "malware"
+      ],
+      "facts": [
+        "Wallet Architecture lives at /delegation/wallet-architecture and is part of the Delegation Center docs.",
+        "The recommended architecture separates a vault wallet for long-term NFT storage, a transaction wallet for trusted marketplace activity, and a minting wallet for unknown or higher-risk minting activity.",
+        "The docs call this the Three Address Protocol, or TAP, and explain how separate wallets reduce phishing, malware, and malicious-site risk.",
+        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet."
+      ],
+      "canonical_path": "/delegation/wallet-architecture",
+      "related_paths": [
+        "/delegation/delegation-faq",
+        "/delegation/consolidation-use-cases",
+        "/delegation/register-delegation",
+        "/delegation/register-consolidation"
+      ],
+      "tags": ["delegation", "wallet", "security", "architecture"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-overview-wallet-architecture.html",
+        "components/delegation/delegation-page-metadata.ts"
+      ]
+    },
+    {
+      "id": "delegation.consolidation-use-cases",
+      "kind": "workflow",
+      "title": "Consolidation Use Cases",
+      "aliases": [
+        "consolidation use cases",
+        "4 wallet consolidation",
+        "four wallet consolidation",
+        "three wallet consolidation",
+        "two wallet consolidation",
+        "compromised wallet consolidation",
+        "consolidation architecture",
+        "how do consolidations affect tdh"
+      ],
+      "keywords": [
+        "consolidation",
+        "wallet",
+        "wallets",
+        "tdh",
+        "cards",
+        "unique",
+        "vault",
+        "minting",
+        "transaction",
+        "compromised",
+        "reciprocal"
+      ],
+      "facts": [
+        "Consolidation Use Cases lives at /delegation/consolidation-use-cases.",
+        "Consolidations help 6529 treat multiple wallets controlled by one collector together for metrics such as total cards, unique cards, TDH, and related collection metrics.",
+        "The docs cover two-address and three-address patterns, plus a four-address scenario where an old hot wallet was compromised and cards moved through temporary, vault, and new minting wallets.",
+        "Each address generally needs reciprocal consolidation records with the other addresses it should be grouped with."
+      ],
+      "canonical_path": "/delegation/consolidation-use-cases",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/register-consolidation",
+        "/delegation/delegation-faq",
+        "/consolidation-mapping-tool"
+      ],
+      "tags": ["delegation", "consolidation", "wallet", "tdh"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/consolidation-use-cases.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address-del-manager.html"
+      ]
+    },
+    {
+      "id": "delegation.faq",
+      "kind": "route",
+      "title": "Delegation FAQ",
+      "aliases": [
+        "delegation faq",
+        "delegation how to",
+        "delegation docs",
+        "delegation help",
+        "delegation guide",
+        "consolidation faq",
+        "wallet delegation faq"
+      ],
+      "keywords": [
+        "delegation",
+        "faq",
+        "how",
+        "register",
+        "view",
+        "manage",
+        "revoke",
+        "lock",
+        "unlock",
+        "safe",
+        "usecase"
+      ],
+      "facts": [
+        "The Delegation FAQ lives at /delegation/delegation-faq.",
+        "It indexes how-to articles for registering delegations, delegation managers, consolidations, SAFE transaction-builder flows, supported use cases, viewing records, updating, revoking, locking, and unlocking wallets.",
+        "Use it when users ask broad Delegation Center how-to questions or ask where the delegation docs live."
+      ],
+      "canonical_path": "/delegation/delegation-faq",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases"
+      ],
+      "tags": ["delegation", "faq", "docs"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/delegation-faq.html",
+        "components/delegation/html/delegationContent.ts"
+      ]
+    },
+    {
+      "id": "delegation.register-delegation-doc",
+      "kind": "workflow",
+      "title": "How to Register a Delegation",
+      "aliases": [
+        "how to register a delegation",
+        "register delegation docs",
+        "register delegation faq",
+        "delegate a wallet",
+        "delegate hot wallet",
+        "delegate minting wallet"
+      ],
+      "keywords": [
+        "delegation",
+        "register",
+        "delegate",
+        "wallet",
+        "collection",
+        "expiry",
+        "token",
+        "utility"
+      ],
+      "facts": [
+        "The register-delegation help article lives at /delegation/delegation-faq/register-delegation.",
+        "To register a delegation, open Delegation Center, choose Register Delegation, choose the collection, enter the delegate wallet, select a use case such as #1 All, choose expiry and token scope, then submit and execute the transaction.",
+        "A delegation lets another wallet use NFT utility without moving the NFT from the delegator wallet."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-delegation",
+      "related_paths": [
+        "/delegation/register-delegation",
+        "/delegation/delegation-center",
+        "/delegation/wallet-architecture"
+      ],
+      "tags": ["delegation", "workflow", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-delegation.html"
+      ]
+    },
+    {
+      "id": "delegation.delegation-manager-doc",
+      "kind": "workflow",
+      "title": "Delegation Manager",
+      "aliases": [
+        "delegation manager",
+        "sub delegation",
+        "sub-delegation",
+        "register delegation manager",
+        "delegation management rights",
+        "manager wallet",
+        "use case 998"
+      ],
+      "keywords": [
+        "delegation",
+        "manager",
+        "sub",
+        "wallet",
+        "rights",
+        "998",
+        "register",
+        "maintain",
+        "consolidations"
+      ],
+      "facts": [
+        "The Delegation Manager help article lives at /delegation/delegation-faq/register-sub-delegation.",
+        "A delegation manager gives a manager wallet permission to maintain delegations and consolidations for another wallet.",
+        "The docs describe registering a manager from the vault wallet to a delegated wallet, then using that delegated wallet to register future delegations or consolidations."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-sub-delegation",
+      "related_paths": [
+        "/delegation/register-sub-delegation",
+        "/delegation/delegation-faq/register-delegation-using-sub-delegation",
+        "/delegation/delegation-faq/revoke-delegation-using-sub-delegation"
+      ],
+      "tags": ["delegation", "manager", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-sub-delegation.html",
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-delegation-using-sub-delegation.html"
+      ]
+    },
+    {
+      "id": "delegation.safe-doc",
+      "kind": "workflow",
+      "title": "Delegate using SAFE",
+      "aliases": [
+        "delegate using safe",
+        "delegate using gnosis",
+        "safe transaction builder",
+        "gnosis transaction builder",
+        "safe wallet delegation",
+        "safe delegation manager"
+      ],
+      "keywords": [
+        "safe",
+        "gnosis",
+        "delegation",
+        "transaction",
+        "builder",
+        "manager",
+        "998",
+        "contract",
+        "abi"
+      ],
+      "facts": [
+        "The SAFE delegation help article lives at /delegation/delegation-faq/using-safe.",
+        "The docs show using the SAFE Transaction Builder with the NFTDelegation.com contract to register delegation manager rights.",
+        "The SAFE flow uses the Any Collection value, no-expiry value, use case 998 for Delegation Management, allTokens true, tokenId 0, then creates and sends the batch transaction."
+      ],
+      "canonical_path": "/delegation/delegation-faq/using-safe",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/delegation-faq/register-sub-delegation"
+      ],
+      "tags": ["delegation", "safe", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/using-safe.html"
       ]
     },
     {

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1315,14 +1315,20 @@
       ]
     },
     {
-      "id": "delegation.register-consolidation",
+      "id": "delegation.register-consolidation-doc",
       "kind": "workflow",
-      "title": "Register Consolidation",
-      "link_label": "Register Consolidation",
+      "title": "How to Register a Consolidation",
+      "link_label": "Register Consolidation Guide",
       "aliases": [
+        "how to register a consolidation",
+        "how do i register a consolidation",
+        "how do i set up a consolidation",
+        "set up consolidation",
+        "setup consolidation",
+        "register consolidation docs",
+        "register consolidation faq",
         "register consolidation",
         "register a consolidation",
-        "how do i register a consolidation",
         "wallet consolidation",
         "consolidate wallets",
         "tdh consolidation",
@@ -1341,16 +1347,57 @@
         "999"
       ],
       "facts": [
-        "Register Consolidation lives at /delegation/register-consolidation and can also be opened from the Delegation Center.",
-        "Use Register Consolidation to connect wallets you control for supported 6529 metrics such as TDH, total cards, and unique cards; it is consolidation use case #999.",
-        "The form requires a connected wallet, Collection, and Consolidating With address; for TDH consolidation, use Any Collection or The Memes.",
+        "A consolidation connects wallets you control so 6529 can treat them together for supported metrics such as TDH, total cards, and unique cards; it is consolidation use case #999.",
+        "To register a consolidation, open Register Consolidation from the Delegation Center, choose the collection, enter the Consolidating With address, submit, and execute the transaction.",
+        "For TDH consolidation, use Any Collection or The Memes.",
         "Consolidation should be reciprocal when two wallets are intended to be treated together, and it is not a delegation and does not grant rights."
+      ],
+      "canonical_path": "/delegation/delegation-faq/register-consolidation",
+      "related_paths": [
+        "/delegation/wallet-architecture",
+        "/delegation/consolidation-use-cases",
+        "/delegation/register-consolidation"
+      ],
+      "tags": ["delegation", "consolidation", "wallet", "faq"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/register-consolidation.html",
+        "ops/docs/delegation/flow-delegation-center-to-onchain-actions.md"
+      ]
+    },
+    {
+      "id": "delegation.register-consolidation",
+      "kind": "workflow",
+      "title": "Register Consolidation Form",
+      "link_label": "Register Consolidation",
+      "aliases": [
+        "register consolidation form",
+        "open register consolidation",
+        "where is register consolidation",
+        "register a consolidation form"
+      ],
+      "keywords": [
+        "consolidation",
+        "consolidate",
+        "register",
+        "wallet",
+        "wallets",
+        "tdh",
+        "primary",
+        "address",
+        "reciprocal",
+        "999"
+      ],
+      "facts": [
+        "The Register Consolidation form is the Delegation Center action for connecting wallets you control for supported 6529 metrics.",
+        "The form requires a connected wallet, Collection, and Consolidating With address.",
+        "For TDH consolidation, use Any Collection or The Memes."
       ],
       "canonical_path": "/delegation/register-consolidation",
       "related_paths": [
-        "/delegation/delegation-center",
-        "/delegation/wallet-checker",
+        "/delegation/delegation-faq/register-consolidation",
+        "/delegation/wallet-architecture",
         "/delegation/consolidation-use-cases",
+        "/delegation/delegation-center",
         "/delegation/assign-primary-address"
       ],
       "tags": ["delegation", "consolidation", "wallet"],
@@ -1368,6 +1415,12 @@
         "wallet architecture",
         "4 wallet architecture",
         "four wallet architecture",
+        "4 wallet consolidation",
+        "four wallet consolidation",
+        "4 wallet setup",
+        "four wallet setup",
+        "how do i set up 4 wallet consolidation",
+        "set up 4 wallet consolidation",
         "three address protocol",
         "tap",
         "vault wallet",
@@ -1393,17 +1446,17 @@
         "malware"
       ],
       "facts": [
-        "Wallet Architecture lives at /delegation/wallet-architecture and is part of the Delegation Center docs.",
         "The recommended architecture separates a vault wallet for long-term NFT storage, a transaction wallet for trusted marketplace activity, and a minting wallet for unknown or higher-risk minting activity.",
         "The docs call this the Three Address Protocol, or TAP, and explain how separate wallets reduce phishing, malware, and malicious-site risk.",
-        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet."
+        "A higher-security version can use SAFE, formerly Gnosis Safe, as the vault wallet, while a more convenient minting wallet can be a hot or mobile wallet.",
+        "Use the consolidation docs and Register Consolidation form when you want those wallets treated together for supported 6529 metrics."
       ],
       "canonical_path": "/delegation/wallet-architecture",
       "related_paths": [
-        "/delegation/delegation-faq",
         "/delegation/consolidation-use-cases",
-        "/delegation/register-delegation",
-        "/delegation/register-consolidation"
+        "/delegation/delegation-faq/register-consolidation",
+        "/delegation/register-consolidation",
+        "/delegation/delegation-faq"
       ],
       "tags": ["delegation", "wallet", "security", "architecture"],
       "source_refs": [
@@ -1439,7 +1492,6 @@
         "reciprocal"
       ],
       "facts": [
-        "Consolidation Use Cases lives at /delegation/consolidation-use-cases.",
         "Consolidations help 6529 treat multiple wallets controlled by one collector together for metrics such as total cards, unique cards, TDH, and related collection metrics.",
         "The docs cover two-address and three-address patterns, plus a four-address scenario where an old hot wallet was compromised and cards moved through temporary, vault, and new minting wallets.",
         "Each address generally needs reciprocal consolidation records with the other addresses it should be grouped with."
@@ -1447,6 +1499,7 @@
       "canonical_path": "/delegation/consolidation-use-cases",
       "related_paths": [
         "/delegation/wallet-architecture",
+        "/delegation/delegation-faq/register-consolidation",
         "/delegation/register-consolidation",
         "/delegation/delegation-faq",
         "/consolidation-mapping-tool"
@@ -1485,7 +1538,6 @@
         "usecase"
       ],
       "facts": [
-        "The Delegation FAQ lives at /delegation/delegation-faq.",
         "It indexes how-to articles for registering delegations, delegation managers, consolidations, SAFE transaction-builder flows, supported use cases, viewing records, updating, revoking, locking, and unlocking wallets.",
         "Use it when users ask broad Delegation Center how-to questions or ask where the delegation docs live."
       ],
@@ -1499,6 +1551,91 @@
       "source_refs": [
         "public/delegation-content/delegation-docs-2026-06-16/html/delegation-faq.html",
         "components/delegation/html/delegationContent.ts"
+      ]
+    },
+    {
+      "id": "delegation.manage-revoke-doc",
+      "kind": "workflow",
+      "title": "How to Revoke a Delegation",
+      "link_label": "Revoke Delegation",
+      "aliases": [
+        "how to revoke a delegation",
+        "how do i revoke a delegation",
+        "revoke delegation",
+        "remove delegation",
+        "cancel delegation",
+        "delete delegation",
+        "revoke a consolidation",
+        "revoke consolidation",
+        "revoke delegation manager"
+      ],
+      "keywords": [
+        "delegation",
+        "revoke",
+        "remove",
+        "cancel",
+        "delete",
+        "manager",
+        "consolidation",
+        "wallet",
+        "manage",
+        "view"
+      ],
+      "facts": [
+        "To revoke a delegation, delegation manager, or consolidation, open the Delegation Center and choose View/Manage for the relevant collection.",
+        "On the Manage/View Collection page, find the address or record you want to revoke and click Revoke.",
+        "Execute the transaction to remove the delegation, manager permission, or consolidation record."
+      ],
+      "canonical_path": "/delegation/delegation-faq/manage-revoke",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq",
+        "/delegation/delegation-faq/revoke-delegation-using-sub-delegation"
+      ],
+      "tags": ["delegation", "workflow", "faq", "revoke"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/manage-revoke.html"
+      ]
+    },
+    {
+      "id": "delegation.manage-update-doc",
+      "kind": "workflow",
+      "title": "How to Update a Delegation",
+      "link_label": "Update Delegation",
+      "aliases": [
+        "how to update a delegation",
+        "how do i update a delegation",
+        "update delegation",
+        "edit delegation",
+        "change delegation",
+        "update consolidation",
+        "update delegation manager"
+      ],
+      "keywords": [
+        "delegation",
+        "update",
+        "edit",
+        "change",
+        "manager",
+        "consolidation",
+        "expiry",
+        "token",
+        "wallet",
+        "manage"
+      ],
+      "facts": [
+        "To update a delegation, delegation manager, or consolidation, open View/Manage in the Delegation Center for the relevant collection.",
+        "Find the address or record you want to update, click Update, adjust the delegated wallet, expiry, or token scope, then submit.",
+        "Execute the transaction to apply the update."
+      ],
+      "canonical_path": "/delegation/delegation-faq/manage-update",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq"
+      ],
+      "tags": ["delegation", "workflow", "faq", "update"],
+      "source_refs": [
+        "public/delegation-content/delegation-docs-2026-06-16/html/manage-update.html"
       ]
     },
     {
@@ -1524,7 +1661,6 @@
         "utility"
       ],
       "facts": [
-        "The register-delegation help article lives at /delegation/delegation-faq/register-delegation.",
         "To register a delegation, open Delegation Center, choose Register Delegation, choose the collection, enter the delegate wallet, select a use case such as #1 All, choose expiry and token scope, then submit and execute the transaction.",
         "A delegation lets another wallet use NFT utility without moving the NFT from the delegator wallet."
       ],
@@ -1564,7 +1700,6 @@
         "consolidations"
       ],
       "facts": [
-        "The Delegation Manager help article lives at /delegation/delegation-faq/register-sub-delegation.",
         "A delegation manager gives a manager wallet permission to maintain delegations and consolidations for another wallet.",
         "The docs describe registering a manager from the vault wallet to a delegated wallet, then using that delegated wallet to register future delegations or consolidations."
       ],
@@ -1604,7 +1739,6 @@
         "abi"
       ],
       "facts": [
-        "The SAFE delegation help article lives at /delegation/delegation-faq/using-safe.",
         "The docs show using the SAFE Transaction Builder with the NFTDelegation.com contract to register delegation manager rights.",
         "The SAFE flow uses the Any Collection value, no-expiry value, use case 998 for Delegation Management, allTokens true, tokenId 0, then creates and sends the batch transaction."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -82,6 +82,265 @@
       "source_refs": ["components/about/AboutFAQ.tsx"]
     },
     {
+      "id": "about.nakamoto-threshold",
+      "kind": "route",
+      "title": "Nakamoto Threshold",
+      "aliases": [
+        "nakamoto threshold",
+        "naka threshold",
+        "what is the nakamoto threshold",
+        "card 4 lowest edition",
+        "meme card 4 edition count",
+        "lowest edition meme card",
+        "300 edition threshold",
+        "the memes threshold"
+      ],
+      "keywords": [
+        "nakamoto",
+        "threshold",
+        "naka",
+        "meme",
+        "memes",
+        "card",
+        "edition",
+        "300",
+        "lowest",
+        "cc0"
+      ],
+      "facts": [
+        "The Nakamoto Threshold page lives at /about/nakamoto-threshold.",
+        "Meme Card #4 is an homage to the first Rare Pepe and has an edition count of 300.",
+        "The Nakamoto Threshold is the commitment that Meme Card #4 remains the lowest-edition Meme Card, so other Meme Cards should exceed 300 editions.",
+        "The page frames the Nakamoto Threshold and CC0 as fixed commitments for The Memes."
+      ],
+      "canonical_path": "/about/nakamoto-threshold",
+      "related_paths": ["/about/the-memes", "/the-memes", "/about/license"],
+      "tags": ["about", "memes", "nakamoto-threshold"],
+      "source_refs": ["components/about/AboutNakamotoThreshold.tsx"]
+    },
+    {
+      "id": "about.data-decentralization",
+      "kind": "route",
+      "title": "Data Decentralization",
+      "aliases": [
+        "data decentralization",
+        "decentralized data",
+        "6529 data sources",
+        "where does 6529 data come from",
+        "can i replicate 6529 data",
+        "open data sources",
+        "public data"
+      ],
+      "keywords": [
+        "data",
+        "decentralization",
+        "decentralized",
+        "on-chain",
+        "ethereum",
+        "arweave",
+        "opensea",
+        "open",
+        "csv",
+        "tdh"
+      ],
+      "facts": [
+        "The Data Decentralization page lives at /about/data-decentralization.",
+        "6529's goal is to demonstrate how applications can be built in a decentralized manner.",
+        "The page explains that effectively all information on 6529.io comes from on-chain or public sources, or is derived transparently from those sources.",
+        "Listed data sources include Ethereum, Arweave decentralized storage, OpenSea API data, internal team-address records, computed thumbnails and TDH values, and compiled daily data exports.",
+        "The page points users to /open-data for daily compiled CSV exports."
+      ],
+      "canonical_path": "/about/data-decentralization",
+      "related_paths": ["/open-data", "/about/faq"],
+      "tags": ["about", "open-data", "decentralization"],
+      "source_refs": ["components/about/AboutDataDecentral.tsx"]
+    },
+    {
+      "id": "about.minting-meme-cards",
+      "kind": "route",
+      "title": "Minting Meme Cards",
+      "aliases": [
+        "minting meme cards",
+        "meme card minting",
+        "how do memes mint",
+        "where do memes mint",
+        "memes mint schedule",
+        "memes mint price",
+        "allowlist minting"
+      ],
+      "keywords": [
+        "minting",
+        "mint",
+        "meme",
+        "memes",
+        "allowlist",
+        "price",
+        "schedule",
+        "primary",
+        "sale"
+      ],
+      "facts": [
+        "The Minting Meme Cards page lives at /about/minting.",
+        "The Memes minting website is /the-memes/mint; there is no other official minting website for The Memes.",
+        "The page says Meme Cards are minted when the art for the next Meme Card is ready, currently about three times per week, though frequency and timing can vary.",
+        "The page says The Memes generally use an allowlist model to avoid gas wars and bot wars and to give a broad range of people a chance to mint.",
+        "Users should follow @6529collections for current mint dates and times."
+      ],
+      "canonical_path": "/about/minting",
+      "related_paths": ["/the-memes/mint", "/the-memes", "/about/the-memes"],
+      "tags": ["about", "memes", "minting"],
+      "source_refs": ["components/about/AboutMinting.tsx"]
+    },
+    {
+      "id": "about.license",
+      "kind": "route",
+      "title": "6529 License",
+      "aliases": [
+        "license",
+        "6529 license",
+        "memes license",
+        "meme lab license",
+        "gradient license",
+        "cc0",
+        "can i use meme card art",
+        "can i use gradient art"
+      ],
+      "keywords": [
+        "license",
+        "cc0",
+        "copyright",
+        "memes",
+        "meme",
+        "lab",
+        "gradient",
+        "commercial",
+        "derivative",
+        "rememes"
+      ],
+      "facts": [
+        "The License page lives at /about/license.",
+        "The Memes and Meme Lab NFTs are released by the artists under a Creative Commons 0 public-domain license to the maximum extent allowed by law.",
+        "The page says people can use The Memes and Meme Lab art for commercial or non-commercial purposes without seeking permission from the artists, subject to rights the artists do not control.",
+        "Gradient NFTs are treated differently: they have not been released under CC0, and the page warns against uses that could confuse people into thinking a product or service is offered by 6529."
+      ],
+      "canonical_path": "/about/license",
+      "related_paths": ["/about/the-memes", "/about/meme-lab", "/about/6529-gradient"],
+      "tags": ["about", "license", "cc0"],
+      "source_refs": ["components/about/AboutLicense.tsx"]
+    },
+    {
+      "id": "about.gdrc1",
+      "kind": "route",
+      "title": "Global Digital Rights Charter",
+      "aliases": [
+        "gdrc1",
+        "gdrc 1",
+        "global digital rights charter",
+        "digital rights charter"
+      ],
+      "keywords": ["gdrc1", "gdrc", "charter", "digital", "rights", "about"],
+      "facts": [
+        "The GDRC1 page lives at /about/gdrc1.",
+        "The page states that 6529 supports the Global Digital Rights Charter 1.",
+        "The page links to digitalrightscharter.org and displays the full text of GDRC1."
+      ],
+      "canonical_path": "/about/gdrc1",
+      "related_paths": ["/about/faq"],
+      "tags": ["about", "rights", "gdrc1"],
+      "source_refs": ["components/about/AboutGDRC1.tsx"]
+    },
+    {
+      "id": "about.nft-delegation",
+      "kind": "route",
+      "title": "NFT Delegation",
+      "aliases": [
+        "nft delegation",
+        "about nft delegation",
+        "delegation about page",
+        "where do i start delegation"
+      ],
+      "keywords": ["nft", "delegation", "delegate", "wallet", "center", "about"],
+      "facts": [
+        "The NFT Delegation about page lives at /about/nft-delegation.",
+        "The page sends users to the Delegation Center to get started with delegation."
+      ],
+      "canonical_path": "/about/nft-delegation",
+      "related_paths": [
+        "/delegation/delegation-center",
+        "/delegation/delegation-faq"
+      ],
+      "tags": ["about", "delegation"],
+      "source_refs": ["components/about/AboutNFTDelegation.tsx"]
+    },
+    {
+      "id": "about.ens",
+      "kind": "route",
+      "title": "ENS",
+      "aliases": [
+        "ens",
+        "ens domain",
+        "ens name",
+        "register ens",
+        "set primary ens",
+        "create ens subdomain",
+        "primary name"
+      ],
+      "keywords": [
+        "ens",
+        "domain",
+        "name",
+        "primary",
+        "subdomain",
+        "subname",
+        "ethereum"
+      ],
+      "facts": [
+        "The ENS page lives at /about/ens.",
+        "The page explains how to register an ENS domain name through ens.domains.",
+        "The page explains how to set an ENS primary name and how to create a subdomain."
+      ],
+      "canonical_path": "/about/ens",
+      "related_paths": ["/about/primary-address", "/{user}/identity"],
+      "tags": ["about", "ens", "identity"],
+      "source_refs": ["public/ens.html", "components/about/AboutHTML.tsx"]
+    },
+    {
+      "id": "about.tech-updates",
+      "kind": "route",
+      "title": "Tech Updates",
+      "aliases": [
+        "tech updates",
+        "about tech",
+        "technical updates",
+        "repo updates",
+        "build reports",
+        "wallet authentication upgrade"
+      ],
+      "keywords": [
+        "tech",
+        "updates",
+        "repo",
+        "reports",
+        "bot",
+        "release",
+        "wallet",
+        "authentication"
+      ],
+      "facts": [
+        "The Tech Updates page lives at /about/tech.",
+        "It is a longer-form area for 6529 tech updates, repo work, bot notes, release context, and build reports.",
+        "Shorter live repo activity still belongs in Follow The Repo.",
+        "The page links active technical notes such as the wallet authentication upgrade and indexes longer tech reports."
+      ],
+      "canonical_path": "/about/tech",
+      "related_paths": [
+        "/about/tech/wallet-authentication",
+        "/about/faq"
+      ],
+      "tags": ["about", "tech", "reports"],
+      "source_refs": ["components/about/tech/AboutTech.tsx"]
+    },
+    {
       "id": "navigation.search",
       "kind": "ui_affordance",
       "title": "Header search",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-19T00:00:00.000Z",
-  "commit_sha": "frontend-owned-curated-v1",
+  "generated_at": "2026-06-29T09:23:18.000Z",
+  "commit_sha": "01a39b18db2f",
   "base_url": "https://6529.io",
   "records": [
     {
@@ -51,9 +51,6 @@
       "kind": "route",
       "title": "6529 FAQ",
       "aliases": [
-        "faq",
-        "6529",
-        "6529.io",
         "6529 faq",
         "what is 6529.io",
         "about faq",
@@ -764,7 +761,7 @@
         "what is x tdh",
         "xtdh grants",
         "xTDH grants",
-        "grants"
+        "xTDH grant allocations"
       ],
       "keywords": [
         "xtdh",
@@ -1642,7 +1639,8 @@
         "how do i set up 4 wallet consolidation",
         "set up 4 wallet consolidation",
         "three address protocol",
-        "tap",
+        "what is tap",
+        "tap wallet architecture",
         "vault wallet",
         "transaction wallet",
         "minting wallet",

--- a/services/api/common-api.ts
+++ b/services/api/common-api.ts
@@ -344,6 +344,7 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
   headers?: Record<string, string> | undefined;
   params?: U | undefined;
   signal?: AbortSignal | undefined;
+  errorMode?: ApiErrorMode | undefined;
 }): Promise<T> => {
   const url = buildUrl(
     param.endpoint,
@@ -362,6 +363,7 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
     method: "GET",
     headers: getHeaders(param.headers, false),
     signal: param.signal,
+    errorMode: param.errorMode ?? "legacy-string",
   });
 };
 

--- a/services/auth/auth-token-fingerprint.ts
+++ b/services/auth/auth-token-fingerprint.ts
@@ -1,0 +1,13 @@
+export const getAuthTokenFingerprint = (
+  jwt: string | null | undefined
+): string => {
+  if (!jwt) {
+    return "none";
+  }
+
+  let hash = 0;
+  for (let index = 0; index < jwt.length; index += 1) {
+    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
+  }
+  return `${jwt.length}:${hash.toString(36)}`;
+};

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -50,6 +50,21 @@ const getJwtExpiration = (jwt: string): number => {
   return decodedJwt.exp;
 };
 
+export const isAuthJwtUsable = (
+  jwt: string | null | undefined,
+  nowSeconds = Date.now() / 1000
+): boolean => {
+  if (!jwt) {
+    return false;
+  }
+
+  try {
+    return getJwtExpiration(jwt) > nowSeconds;
+  } catch {
+    return false;
+  }
+};
+
 const getAddressRoleStorageKey = (address: string): string => {
   return `auth-role-${address.toLowerCase()}`;
 };

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -16,6 +16,17 @@ const WALLET_REFRESH_TOKEN_STORAGE_KEY = "6529-wallet-refresh-token";
 const WALLET_ROLE_STORAGE_KEY = "6529-wallet-role";
 const WALLET_ACCOUNTS_STORAGE_KEY = "6529-wallet-accounts";
 const WALLET_ACTIVE_ADDRESS_STORAGE_KEY = "6529-wallet-active-address";
+export const AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY =
+  "6529-agent-login-active-address";
+export const AUTH_STORAGE_KEYS = {
+  accounts: WALLET_ACCOUNTS_STORAGE_KEY,
+  activeAddress: WALLET_ACTIVE_ADDRESS_STORAGE_KEY,
+  legacyAddress: WALLET_ADDRESS_STORAGE_KEY,
+  legacyRefreshToken: WALLET_REFRESH_TOKEN_STORAGE_KEY,
+  legacyRole: WALLET_ROLE_STORAGE_KEY,
+  agentLoginActiveAddress: AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
+  authCookie: WALLET_AUTH_COOKIE,
+} as const;
 
 export interface ConnectedWalletAccount {
   readonly address: string;
@@ -44,6 +55,24 @@ const getAddressRoleStorageKey = (address: string): string => {
 };
 
 const normalizeAddress = (address: string): string => address.toLowerCase();
+
+const clearAgentLoginMarkerIfAddressChanged = (
+  activeAddress: string | null
+): void => {
+  const agentLoginAddress = safeLocalStorage.getItem(
+    AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY
+  );
+  if (!agentLoginAddress) {
+    return;
+  }
+
+  if (
+    !activeAddress ||
+    normalizeAddress(agentLoginAddress) !== normalizeAddress(activeAddress)
+  ) {
+    safeLocalStorage.removeItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY);
+  }
+};
 
 export const isAuthAddressAuthorized = ({
   address,
@@ -326,6 +355,7 @@ const persistAccountsWithActive = (
 ): void => {
   writeAccountsToStorage(accounts);
   setActiveAddressInStorage(activeAddress);
+  clearAgentLoginMarkerIfAddressChanged(activeAddress);
 
   const activeAccount =
     activeAddress === null
@@ -484,6 +514,33 @@ export const hasActiveSessionV2Auth = ({
     storedAccount?.authSessionVersion === "v2" &&
     normalizeAddress(storedAccount.address) === normalizedAddress
   );
+};
+
+export const setAgentLoginActiveAddress = (address: string): void => {
+  safeLocalStorage.setItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY, address);
+};
+
+export const clearAgentLoginActiveAddress = (): void => {
+  safeLocalStorage.removeItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY);
+};
+
+export const getAgentLoginActiveAddress = (): string | null => {
+  const agentLoginAddress = safeLocalStorage.getItem(
+    AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY
+  );
+  if (!agentLoginAddress) {
+    return null;
+  }
+
+  const activeAccount = getActiveAccountFromAccounts(getStoredAccounts());
+  if (
+    activeAccount?.authSessionVersion !== "v2" ||
+    normalizeAddress(activeAccount.address) !== normalizeAddress(agentLoginAddress)
+  ) {
+    return null;
+  }
+
+  return activeAccount.address;
 };
 
 export const getRefreshToken = () => {


### PR DESCRIPTION
## Summary
- Merges latest `main` changes into the long-lived `pull-web` renderer sync branch.
- Resolves conflicts in `renderer/components/auth/SeizeConnectContext.tsx` by preserving desktop/browser-connector live account handling while keeping the incoming agent-login impersonation cleanup.
- Resolves `renderer/hooks/useUnreadNotifications.ts` to the incoming auth-aware notification polling behavior.

## Validation
- `6529 run type-check` passed after removing ignored stale generated `renderer/out` build output from the local checkout.

## Notes
- No desktop release/build scripts were run.
- This PR is opened only; it has not been merged.