### PR TITLE
[codex] Remove core Bootstrap and SCSS styling

### DIFF
--- a/renderer/app/core/core-info/page.tsx
+++ b/renderer/app/core/core-info/page.tsx
@@ -1,11 +1,10 @@
 import AppInfo from "@/components/core/app-info/AppInfo";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import { Metadata } from "next";
 
 export default function AppInfoPage() {
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <AppInfo />
       </div>

--- a/renderer/app/core/core-wallets/[address]/page.tsx
+++ b/renderer/app/core/core-wallets/[address]/page.tsx
@@ -1,6 +1,5 @@
 import SeedWallet from "@/components/core/core-wallet/SeedWallet";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import { Metadata } from "next";
 
 export default async function SeedWalletPage({
@@ -11,7 +10,7 @@ export default async function SeedWalletPage({
   const { address } = await params;
 
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <SeedWallet address={address} />
       </div>

--- a/renderer/app/core/core-wallets/import-wallet/page.tsx
+++ b/renderer/app/core/core-wallets/import-wallet/page.tsx
@@ -1,11 +1,10 @@
 import SeedWalletImport from "@/components/core/core-wallet/SeedWalletImport";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import { Metadata } from "next";
 
 export default function SeedWalletPage() {
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <SeedWalletImport />
       </div>

--- a/renderer/app/core/core-wallets/page.tsx
+++ b/renderer/app/core/core-wallets/page.tsx
@@ -1,11 +1,10 @@
 import CoreWallets from "@/components/core/core-wallet/SeedWallets";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import { Metadata } from "next";
 
 export default function SeedWalletPage() {
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <CoreWallets />
       </div>

--- a/renderer/app/core/eth-transactions/page.tsx
+++ b/renderer/app/core/eth-transactions/page.tsx
@@ -1,11 +1,10 @@
 import ETHScanner from "@/components/core/eth-scanner/ETHScanner";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import { Metadata } from "next";
 
 export default function ETHScannerPage() {
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <ETHScanner />
       </div>

--- a/renderer/app/core/tdh-calculation/page.tsx
+++ b/renderer/app/core/tdh-calculation/page.tsx
@@ -1,11 +1,10 @@
 import TDHCalculation from "@/components/core/tdh-calculation/TDHCalculation";
 import { getAppMetadata } from "@/components/providers/metadata";
-import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
 export default function TDHConsensusPage() {
   return (
-    <main className={styles["main"]}>
+    <main className="tw-min-h-screen">
       <div className="tw-relative tw-mx-auto tw-px-2 lg:tw-px-6 xl:tw-px-8">
         <TDHCalculation />
       </div>

--- a/renderer/components/core/core-wallet/SeedWalletCard.tsx
+++ b/renderer/components/core/core-wallet/SeedWalletCard.tsx
@@ -10,7 +10,7 @@ export default function SeedWalletCard(
   return (
     <Link
       href={`/core/core-wallets/${props.wallet.address}`}
-      className="group tw-block tw-no-underline tw-transition-transform tw-duration-300 desktop-hover:hover:tw-scale-[1.01]"
+      className="tw-group tw-block tw-no-underline tw-transition-transform tw-duration-300 desktop-hover:hover:tw-scale-[1.01]"
     >
       <div className="tw-rounded-xl tw-bg-iron-950 tw-px-4 tw-py-6 tw-ring-1 tw-ring-inset tw-ring-iron-800 tw-transition-all tw-duration-300 hover:tw-ring-iron-600">
         <div className="tw-flex tw-items-center tw-gap-2 tw-break-all">

--- a/renderer/components/core/eth-scanner/RpcProviders.tsx
+++ b/renderer/components/core/eth-scanner/RpcProviders.tsx
@@ -97,7 +97,7 @@ function RPCProviderCard({
               {!rpcProvider.deletable && (
                 <>
                   <span
-                    className="cursor-help"
+                    className="tw-cursor-help"
                     data-tooltip-id="default-rpc-provider-tooltip"
                   >
                     *

--- a/renderer/components/core/logs-viewer/LogsViewer.module.scss
+++ b/renderer/components/core/logs-viewer/LogsViewer.module.scss
@@ -1,5 +1,0 @@
-.accordionButtonOpen {
-  &::after {
-    transform: rotate(180deg);
-  }
-}

--- a/renderer/components/core/logs-viewer/LogsViewer.tsx
+++ b/renderer/components/core/logs-viewer/LogsViewer.tsx
@@ -40,15 +40,17 @@ function LogsViewerTrigger({
     : isOpen
       ? "tw-bg-iron-900"
       : "tw-bg-black desktop-hover:hover:tw-bg-iron-900";
+  const chevronRotationClass = isOpen ? "tw-rotate-90" : "tw-rotate-0";
   return (
     <button
       type="button"
       style={summaryStyle ? undefined : { maxWidth: width }}
+      aria-expanded={isOpen}
       className={`tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-text-left tw-text-inherit focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-iron-500 ${summaryStyle ? summaryClasses : defaultClasses} ${stateClasses}`}
       onClick={onSelect}
     >
       <ChevronRightIcon
-        className={`tw-size-4 tw-shrink-0 tw-text-inherit tw-transition-transform ${isOpen ? "tw-rotate-90" : ""}`}
+        className={`tw-size-4 tw-shrink-0 tw-text-inherit tw-transition-transform ${chevronRotationClass}`}
       />
       <span className="tw-truncate">{children}</span>
     </button>


### PR DESCRIPTION
## Issue
- Core desktop routes and their fetched component tree should not rely on Bootstrap-style classes, repo-specific SCSS/CSS modules, or unprefixed legacy styling tokens.

## Fix
- Replaced the legacy `Home.module.scss` route-shell dependency on core pages with the equivalent Tailwind `tw-min-h-screen` utility.
- Removed the unused `LogsViewer.module.scss` file from `renderer/components/core`.
- Made the core logs viewer's open-state chevron rotation explicit in `LogsViewer.tsx` with Tailwind classes and `aria-expanded`, so the removed SCSS behavior is visible in the diff.
- Normalized remaining unprefixed utility tokens inside `renderer/components/core` to the repo's `tw-` Tailwind prefix.
- Confirmed the seed-wallet unlock modal is already rendered through the shared Tailwind modal shell rather than Bootstrap/SCSS styling.

## Changes
- Updated the six `/core` route shells to use Tailwind directly.
- Deleted the obsolete core logs viewer SCSS module.
- Updated the logs viewer trigger to expose expanded state and state-driven Tailwind rotation.
- Updated core wallet and RPC provider component classes from unprefixed utilities to `tw-` utilities.
- Left shared non-core legacy styles untouched outside this scoped core route/component cleanup.

## Validation
- `./bin/6529 run type-check`
- `git diff --check`
- Searched `renderer/app/core` and `renderer/components/core` for remaining SCSS/CSS files, SCSS/CSS imports, CSS module references, Bootstrap references, and React Bootstrap references.
- Ran a static class-token scan over `renderer/components/core` to catch unprefixed class tokens.
- Local build was visually checked by the requester after the initial cleanup; no additional browser screenshots were collected for the follow-up because it only makes existing logs-viewer rotation state explicit.

## Risk
- Level: Low
- Why: This is a narrow styling dependency cleanup with equivalent route shell min-height behavior, equivalent utility prefix changes, explicit logs-viewer rotation state, and removal of an unused SCSS module.
- Rollback: Revert the branch commits to restore the previous route wrapper import, unprefixed component tokens, and deleted SCSS file.

## Review Notes
- Latest bot follow-up addressed: `LogsViewer.tsx` is now included in the diff and shows no SCSS import/reference, while preserving chevron rotation with Tailwind classes.
- The responsiveness bot's reported `sendSync` app-shell boot failure appears unrelated to this scoped styling cleanup and was not changed here.