### PR TITLE
[codex] Update TDH edition size floors

### DIFF
--- a/electron-constants.ts
+++ b/electron-constants.ts
@@ -22,6 +22,7 @@ export const SET_RPC_PROVIDER_ACTIVE = "setRpcProviderActive";
 export const DEACTIVATE_RPC_PROVIDER = "deactivateRpcProvider";
 export const DELETE_RPC_PROVIDER = "deleteRpcProvider";
 export const MANUAL_START_WORKER = "manualStartWorker";
+export const FULL_REFRESH_WORKER = "fullRefreshWorker";
 export const RESET_TRANSACTIONS_TO_BLOCK = "resetTransactionsToBlock";
 export const RECALCULATE_TRANSACTIONS_OWNERS = "recalculateTransactionsOwners";
 export const RESET_WORKER = "resetWorker";

--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -5,23 +5,46 @@ import { Transaction } from "./entities/ITransaction";
 import { NULL_ADDRESS } from "../../electron-constants";
 import { NEXTGEN_CONTRACT } from "../../shared/abis/nextgen";
 import { findTransactionValues } from "../scheduled-tasks/workers/transactions-worker/transaction-values";
-import { JsonRpcProvider } from "ethers";
+import { ethers, JsonRpcProvider } from "ethers";
+import { NFT } from "./entities/INFT";
+import {
+  Contract,
+  ContractType,
+  getEditionSizes,
+  getTokenUri,
+  retrieveNftFromURI,
+} from "../scheduled-tasks/workers/nft-worker/nft-worker";
+import { MEMES_ABI, MEMES_CONTRACT } from "../../shared/abis/memes";
+import { areEqualAddresses } from "../../shared/helpers";
 
 const loggerName = "[DB MIGRATIONS]";
+const EDITION_SIZE_FLOOR_FULL_REFRESH_THRESHOLD = 300;
 
 export async function runCoreMigrations(dataSource: DataSource) {
   await runBlurRoyaltiesMigration(dataSource);
+  await runNftEditionSizeFloorMigration(dataSource);
 }
 
-async function runBlurRoyaltiesMigration(dataSource: DataSource) {
-  const migrationName = "blurRoyalties";
-
+async function hasMigrationRun(
+  dataSource: DataSource,
+  migrationName: string
+) {
   const existing = await dataSource.getRepository(CoreMigration).findOne({
     where: { migration_name: migrationName },
   });
 
   if (existing) {
     Logger.info(loggerName, `Migration ${migrationName} already applied.`);
+    return true;
+  }
+
+  return false;
+}
+
+async function runBlurRoyaltiesMigration(dataSource: DataSource) {
+  const migrationName = "blurRoyalties";
+
+  if (await hasMigrationRun(dataSource, migrationName)) {
     return;
   }
 
@@ -77,4 +100,183 @@ async function runBlurRoyaltiesMigration(dataSource: DataSource) {
   });
 
   Logger.info(loggerName, `Migration ${migrationName} completed.`);
+}
+
+const MEMES_CONTRACT_OBJECT: Contract = {
+  name: "The Memes",
+  address: MEMES_CONTRACT,
+  abi: MEMES_ABI,
+  type: ContractType.ERC1155,
+};
+
+function getPositiveEditionSize(editionSize: number): number {
+  return Number.isInteger(editionSize) && editionSize > 0 ? editionSize : 0;
+}
+
+async function updateEditionSizeFloor(
+  dataSource: DataSource,
+  nft: NFT,
+  editionSizeFloor: number
+) {
+  if (nft.edition_size_floor === editionSizeFloor) {
+    return false;
+  }
+
+  await dataSource.getRepository(NFT).update(
+    {
+      contract: nft.contract,
+      id: nft.id,
+    },
+    {
+      edition_size_floor: editionSizeFloor,
+    }
+  );
+
+  return true;
+}
+
+async function refreshNftEditionSizeFloor(
+  dataSource: DataSource,
+  provider: ethers.JsonRpcProvider,
+  nft: NFT,
+  contract: Contract
+) {
+  const ethersContract = new ethers.Contract(
+    contract.address,
+    contract.abi,
+    provider
+  );
+  const editionSizes = await getEditionSizes(
+    dataSource,
+    contract.address,
+    ethersContract,
+    nft.id,
+    {
+      provider,
+      refreshEditionSizeFloor: true,
+      backfillMissingEditionSizeFloor: true,
+    }
+  );
+
+  const tokenUri = await getTokenUri(contract.type, ethersContract, nft.id);
+  const metadataUri = tokenUri || nft.uri;
+
+  if (metadataUri) {
+    try {
+      const updatedNft = await retrieveNftFromURI(
+        dataSource,
+        contract.address,
+        nft.id,
+        metadataUri,
+        editionSizes
+      );
+      await dataSource.getRepository(NFT).save(updatedNft);
+      return "full";
+    } catch (error) {
+      Logger.warn(
+        loggerName,
+        `Failed to refresh metadata for ${contract.name} #${nft.id}; saving edition-size fields only.`,
+        error
+      );
+    }
+  }
+
+  await dataSource.getRepository(NFT).update(
+    {
+      contract: nft.contract,
+      id: nft.id,
+    },
+    {
+      edition_size: editionSizes.editionSize,
+      edition_size_floor: editionSizes.editionSizeFloor,
+      burns: editionSizes.burnt,
+    }
+  );
+
+  return "fields";
+}
+
+async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
+  const migrationName = "nftEditionSizeFloorBackfill";
+
+  if (await hasMigrationRun(dataSource, migrationName)) {
+    return;
+  }
+
+  Logger.info(loggerName, `Running migration ${migrationName}...`);
+
+  const nftRepository = dataSource.getRepository(NFT);
+  const nfts = await nftRepository.find({
+    order: {
+      contract: "ASC",
+      id: "ASC",
+    },
+  });
+
+  Logger.info(loggerName, `Found ${nfts.length} NFTs to scan`);
+
+  const provider = new JsonRpcProvider("https://rpc1.6529.io");
+  let copiedFloors = 0;
+  let fullRefreshes = 0;
+  let fieldRefreshes = 0;
+  let nonMemeFloors = 0;
+  let failedRefreshes = 0;
+
+  for (const nft of nfts) {
+    const editionSize = getPositiveEditionSize(nft.edition_size);
+
+    if (!areEqualAddresses(nft.contract, MEMES_CONTRACT)) {
+      if (await updateEditionSizeFloor(dataSource, nft, editionSize)) {
+        copiedFloors++;
+      }
+      nonMemeFloors++;
+      continue;
+    }
+
+    if (editionSize >= EDITION_SIZE_FLOOR_FULL_REFRESH_THRESHOLD) {
+      if (await updateEditionSizeFloor(dataSource, nft, editionSize)) {
+        copiedFloors++;
+      }
+      continue;
+    }
+
+    try {
+      const refreshResult = await refreshNftEditionSizeFloor(
+        dataSource,
+        provider,
+        nft,
+        MEMES_CONTRACT_OBJECT
+      );
+      if (refreshResult === "full") {
+        fullRefreshes++;
+      } else {
+        fieldRefreshes++;
+      }
+    } catch (error) {
+      failedRefreshes++;
+      Logger.warn(
+        loggerName,
+        `Failed to refresh The Memes #${nft.id}; migration will retry on next startup.`,
+        error
+      );
+    }
+  }
+
+  if (failedRefreshes === 0) {
+    await dataSource.getRepository(CoreMigration).insert({
+      migration_name: migrationName,
+    });
+  }
+
+  Logger.info(
+    loggerName,
+    failedRefreshes === 0
+      ? `Migration ${migrationName} completed.`
+      : `Migration ${migrationName} partially completed and will retry.`,
+    `Copied floors: ${copiedFloors}.`,
+    `Full refreshes: ${fullRefreshes}.`,
+    `Field refreshes: ${fieldRefreshes}.`,
+    `Non-Meme rows normalized: ${nonMemeFloors}.`,
+    `Failed refreshes: ${failedRefreshes}.`
+  );
 }

--- a/electron-src/db/db.ts
+++ b/electron-src/db/db.ts
@@ -13,6 +13,7 @@ import { registerIpcHandlers } from "./db.operations";
 import { ipcMain } from "electron";
 import { Transaction } from "./entities/ITransaction";
 import { CoreMigration } from "./entities/ICoreMigration";
+import { NFT } from "./entities/INFT";
 
 let AppDataSource: DataSource;
 
@@ -161,6 +162,7 @@ export const initDb = async () => {
         ConsolidatedTDH,
         Transaction,
         CoreMigration,
+        NFT,
       ],
       synchronize: true,
     });

--- a/electron-src/db/entities/INFT.ts
+++ b/electron-src/db/entities/INFT.ts
@@ -52,6 +52,9 @@ export class NFT {
   edition_size!: number;
 
   @Column({ type: "int", default: 0 })
+  edition_size_floor!: number;
+
+  @Column({ type: "int", default: 0 })
   burns!: number;
 
   @Column({ type: "text" })

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -24,6 +24,7 @@ import {
   DEACTIVATE_RPC_PROVIDER,
   DELETE_RPC_PROVIDER,
   DELETE_SEED_WALLET,
+  FULL_REFRESH_WORKER,
   GET_SEED_WALLET,
   GET_SEED_WALLETS,
   IMPORT_SEED_WALLET,
@@ -2017,6 +2018,26 @@ ipcMain.on(MANUAL_START_WORKER, (event, namespace: string) => {
     event.returnValue = { error: !status };
   } else {
     event.returnValue = { error: true, data: "Worker not found" };
+  }
+});
+
+ipcMain.on(FULL_REFRESH_WORKER, (event, args: [string]) => {
+  const [namespace] = args;
+  Logger.info(`[${namespace}] Full refresh worker`);
+  const worker = scheduledWorkers.find(
+    (worker) =>
+      worker instanceof ResettableScheduledWorker &&
+      worker.getNamespace() === namespace,
+  ) as ResettableScheduledWorker | undefined;
+  if (!worker) {
+    event.returnValue = {
+      error: true,
+      data: "Worker not found",
+    };
+  } else {
+    worker.fullRefresh().then((data) => {
+      event.returnValue = { error: !data.status, data: data.message };
+    });
   }
 });
 

--- a/electron-src/index.ts
+++ b/electron-src/index.ts
@@ -2021,7 +2021,7 @@ ipcMain.on(MANUAL_START_WORKER, (event, namespace: string) => {
   }
 });
 
-ipcMain.on(FULL_REFRESH_WORKER, (event, args: [string]) => {
+ipcMain.handle(FULL_REFRESH_WORKER, async (_event, args: [string]) => {
   const [namespace] = args;
   Logger.info(`[${namespace}] Full refresh worker`);
   const worker = scheduledWorkers.find(
@@ -2030,15 +2030,14 @@ ipcMain.on(FULL_REFRESH_WORKER, (event, args: [string]) => {
       worker.getNamespace() === namespace,
   ) as ResettableScheduledWorker | undefined;
   if (!worker) {
-    event.returnValue = {
+    return {
       error: true,
       data: "Worker not found",
     };
-  } else {
-    worker.fullRefresh().then((data) => {
-      event.returnValue = { error: !data.status, data: data.message };
-    });
   }
+
+  const data = await worker.fullRefresh();
+  return { error: !data.status, data: data.message };
 });
 
 ipcMain.on(RESET_TRANSACTIONS_TO_BLOCK, (event, args: [string, number]) => {

--- a/electron-src/preload.ts
+++ b/electron-src/preload.ts
@@ -21,6 +21,9 @@ export const api = {
   sendSync: (channel: string, ...args: any[]): any => {
     return ipcRenderer.sendSync(channel, args);
   },
+  invoke: (channel: string, ...args: any[]): Promise<any> => {
+    return ipcRenderer.invoke(channel, args);
+  },
   openExternal: (url: string): void => {
     ipcRenderer.send("open-external", url);
   },

--- a/electron-src/scheduled-tasks/scheduled-worker.ts
+++ b/electron-src/scheduled-tasks/scheduled-worker.ts
@@ -388,7 +388,10 @@ export class ResettableScheduledWorker extends ScheduledWorker {
     );
   }
 
-  public async reset() {
+  private async startResettableRun(
+    flag: "reset" | "refresh",
+    startedMessage: string
+  ) {
     if (this.worker || this.isRunning()) {
       return {
         status: false,
@@ -408,45 +411,22 @@ export class ResettableScheduledWorker extends ScheduledWorker {
       dbParams: getBaseDbParams(),
       blockRange: this.blockRange,
       maxConcurrentRequests: this.maxConcurrentRequests,
-      reset: true,
+      [flag]: true,
     } as ResettableWorkerData;
 
     this.startWorker(workerData);
 
     return {
       status: true,
-      message: `Reset started`,
+      message: startedMessage,
     };
   }
 
+  public async reset() {
+    return this.startResettableRun("reset", "Reset started");
+  }
+
   public async fullRefresh() {
-    if (this.worker || this.isRunning()) {
-      return {
-        status: false,
-        message: "Worker is already running",
-      };
-    }
-
-    if (!this.enabled) {
-      return {
-        status: false,
-        message: "Worker is disabled",
-      };
-    }
-
-    const workerData: ResettableWorkerData = {
-      rpcUrl: this.rpcUrl,
-      dbParams: getBaseDbParams(),
-      blockRange: this.blockRange,
-      maxConcurrentRequests: this.maxConcurrentRequests,
-      refresh: true,
-    } as ResettableWorkerData;
-
-    this.startWorker(workerData);
-
-    return {
-      status: true,
-      message: `Full refresh started`,
-    };
+    return this.startResettableRun("refresh", "Full refresh started");
   }
 }

--- a/electron-src/scheduled-tasks/scheduled-worker.ts
+++ b/electron-src/scheduled-tasks/scheduled-worker.ts
@@ -25,6 +25,7 @@ export interface TransactionsWorkerData extends WorkerData {
 
 export interface ResettableWorkerData extends WorkerData {
   reset?: boolean;
+  refresh?: boolean;
 }
 
 export class ScheduledWorker {
@@ -415,6 +416,37 @@ export class ResettableScheduledWorker extends ScheduledWorker {
     return {
       status: true,
       message: `Reset started`,
+    };
+  }
+
+  public async fullRefresh() {
+    if (this.worker || this.isRunning()) {
+      return {
+        status: false,
+        message: "Worker is already running",
+      };
+    }
+
+    if (!this.enabled) {
+      return {
+        status: false,
+        message: "Worker is disabled",
+      };
+    }
+
+    const workerData: ResettableWorkerData = {
+      rpcUrl: this.rpcUrl,
+      dbParams: getBaseDbParams(),
+      blockRange: this.blockRange,
+      maxConcurrentRequests: this.maxConcurrentRequests,
+      refresh: true,
+    } as ResettableWorkerData;
+
+    this.startWorker(workerData);
+
+    return {
+      status: true,
+      message: `Full refresh started`,
     };
   }
 }

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
@@ -13,6 +13,7 @@ import {
   Contract,
   ContractType,
   getEditionSizes,
+  getMemeTokenIdsForEditionSizeFloorRefresh,
   getMintDate,
   getTokenUri,
   retrieveNftFromURI,
@@ -26,6 +27,7 @@ import {
   GRADIENT_ABI,
 } from "../../../../shared/abis/gradient";
 import { NEXTGEN_CONTRACT, NEXTGEN_ABI } from "../../../../shared/abis/nextgen";
+import { areEqualAddresses } from "../../../../shared/helpers";
 import { Transaction } from "../../../db/entities/ITransaction";
 
 const data: ResettableWorkerData = workerData;
@@ -65,7 +67,7 @@ class NFTWorker extends CoreWorker {
     dbParams: DataSourceOptions,
     blockRange: number,
     maxConcurrentRequests: number,
-    reset?: boolean
+    reset?: boolean,
   ) {
     super(rpcUrl, dbParams, blockRange, maxConcurrentRequests, parentPort, [
       NFT,
@@ -164,7 +166,7 @@ class NFTWorker extends CoreWorker {
     const ethersContract = new ethers.Contract(
       contract.address,
       contract.abi,
-      this.getProvider()
+      this.getProvider(),
     );
 
     const printStatus = (...args: any[]) => {
@@ -215,12 +217,20 @@ class NFTWorker extends CoreWorker {
           this.getDb(),
           contract.address,
           ethersContract,
-          nextId
+          nextId,
+          {
+            provider: this.getProvider(),
+            refreshEditionSizeFloor: true,
+          },
         );
         printStatus(
           `NFT #${nextId} edition size: ${editionSizes.editionSize}${
             editionSizes.burnt > 0 ? ` (burns: ${editionSizes.burnt})` : ""
-          }`
+          }${
+            editionSizes.editionSizeFloor !== editionSizes.editionSize
+              ? ` (floor: ${editionSizes.editionSizeFloor})`
+              : ""
+          }`,
         );
 
         const newNft = await retrieveNftFromURI(
@@ -228,7 +238,7 @@ class NFTWorker extends CoreWorker {
           contract.address,
           nextId,
           uri,
-          editionSizes
+          editionSizes,
         );
         await persistNfts(this.getDb(), [newNft]);
         sendUpdate(`New NFT: #${nextId} - Completed`);
@@ -244,7 +254,7 @@ class NFTWorker extends CoreWorker {
     const ethersContract = new ethers.Contract(
       NEXTGEN_CONTRACT,
       NEXTGEN_ABI,
-      this.getProvider()
+      this.getProvider(),
     );
 
     const printStatus = (...args: any[]) => {
@@ -288,7 +298,7 @@ class NFTWorker extends CoreWorker {
       const uri = await getTokenUri(
         ContractType.ERC721,
         ethersContract,
-        nextId
+        nextId,
       );
 
       if (uri && uri != nextId) {
@@ -297,19 +307,23 @@ class NFTWorker extends CoreWorker {
 
         printStatus(`NFT #${nextId} found`);
         sendUpdate(
-          `New NFT: Collection ${collectionId} #${normalisedTokenId} - Processing`
+          `New NFT: Collection ${collectionId} #${normalisedTokenId} - Processing`,
         );
 
         const editionSizes = await getEditionSizes(
           this.getDb(),
           NEXTGEN_CONTRACT,
           ethersContract,
-          nextId
+          nextId,
+          {
+            provider: this.getProvider(),
+            refreshEditionSizeFloor: false,
+          },
         );
         printStatus(
           `NFT #${nextId} edition size: ${editionSizes.editionSize}${
             editionSizes.burnt > 0 ? ` (burnt)` : ""
-          }`
+          }`,
         );
 
         const newNft = await retrieveNftFromURI(
@@ -317,12 +331,12 @@ class NFTWorker extends CoreWorker {
           NEXTGEN_CONTRACT,
           nextId,
           uri,
-          editionSizes
+          editionSizes,
         );
 
         await persistNfts(this.getDb(), [newNft]);
         sendUpdate(
-          `New NFT: Collection ${collectionId} #${normalisedTokenId} - Completed`
+          `New NFT: Collection ${collectionId} #${normalisedTokenId} - Completed`,
         );
         nextId++;
       } else {
@@ -336,7 +350,7 @@ class NFTWorker extends CoreWorker {
     const ethersContract = new ethers.Contract(
       contract.address,
       contract.abi,
-      this.getProvider()
+      this.getProvider(),
     );
 
     const existingNfts = await this.getDb()
@@ -349,6 +363,11 @@ class NFTWorker extends CoreWorker {
           id: "ASC",
         },
       });
+    const refreshEditionSizeFloorTokenIds = new Set(
+      areEqualAddresses(contract.address, MEMES_CONTRACT)
+        ? getMemeTokenIdsForEditionSizeFloorRefresh(existingNfts)
+        : [],
+    );
 
     const updatedNfts: NFT[] = [];
     for (const nft of existingNfts) {
@@ -364,16 +383,21 @@ class NFTWorker extends CoreWorker {
         this.getDb(),
         contract.address,
         ethersContract,
-        nft.id
+        nft.id,
+        {
+          provider: this.getProvider(),
+          refreshEditionSizeFloor: refreshEditionSizeFloorTokenIds.has(nft.id),
+        },
       );
       const mintDate = await getMintDate(
         this.getDb(),
         contract.address,
-        nft.id
+        nft.id,
       );
 
       const isChanged =
         editionSizes.editionSize !== nft.edition_size ||
+        editionSizes.editionSizeFloor !== nft.edition_size_floor ||
         editionSizes.burnt !== nft.burns ||
         mintDate !== nft.mint_date;
 
@@ -390,7 +414,7 @@ class NFTWorker extends CoreWorker {
           contract.address,
           nft.id,
           uri,
-          editionSizes
+          editionSizes,
         );
         updatedNfts.push(updatedNft);
       }
@@ -440,5 +464,5 @@ new NFTWorker(
   data.dbParams,
   data.blockRange,
   data.maxConcurrentRequests,
-  data.reset
+  data.reset,
 );

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
@@ -13,7 +13,6 @@ import {
   Contract,
   ContractType,
   getEditionSizes,
-  getMemeTokenIdsForEditionSizeFloorRefresh,
   getMintDate,
   getTokenUri,
   retrieveNftFromURI,
@@ -28,6 +27,9 @@ import {
 } from "../../../../shared/abis/gradient";
 import { NEXTGEN_CONTRACT, NEXTGEN_ABI } from "../../../../shared/abis/nextgen";
 import { areEqualAddresses } from "../../../../shared/helpers";
+import {
+  getMemeTokenIdsForEditionSizeFloorRefresh,
+} from "../../../../shared/memes-edition-size-floor";
 import { Transaction } from "../../../db/entities/ITransaction";
 
 const data: ResettableWorkerData = workerData;
@@ -61,6 +63,7 @@ export const NAMESPACE = "NFTS_WORKER >";
 
 class NFTWorker extends CoreWorker {
   private reset?: boolean;
+  private refresh?: boolean;
 
   constructor(
     rpcUrl: string,
@@ -68,12 +71,14 @@ class NFTWorker extends CoreWorker {
     blockRange: number,
     maxConcurrentRequests: number,
     reset?: boolean,
+    refresh?: boolean,
   ) {
     super(rpcUrl, dbParams, blockRange, maxConcurrentRequests, parentPort, [
       NFT,
       Transaction,
     ]);
     this.reset = reset;
+    this.refresh = refresh;
   }
 
   async sendStatusMessage() {
@@ -100,7 +105,10 @@ class NFTWorker extends CoreWorker {
 
     if (this.reset) {
       return await this.resetWork();
-    } else if (currentHour % 2 === 0 && currentMinute === 0) {
+    } else if (
+      this.refresh ||
+      (currentHour % 2 === 0 && currentMinute === 0)
+    ) {
       return await this.refreshWork();
     } else {
       return await this.normalWork();
@@ -220,7 +228,7 @@ class NFTWorker extends CoreWorker {
           nextId,
           {
             provider: this.getProvider(),
-            refreshEditionSizeFloor: true,
+            refreshEditionSizeFloor: false,
           },
         );
         printStatus(
@@ -387,6 +395,7 @@ class NFTWorker extends CoreWorker {
         {
           provider: this.getProvider(),
           refreshEditionSizeFloor: refreshEditionSizeFloorTokenIds.has(nft.id),
+          backfillMissingEditionSizeFloor: true,
         },
       );
       const mintDate = await getMintDate(
@@ -465,4 +474,5 @@ new NFTWorker(
   data.blockRange,
   data.maxConcurrentRequests,
   data.reset,
+  data.refresh,
 );

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
@@ -47,6 +47,8 @@ interface GetEditionSizesOptions {
   backfillMissingEditionSizeFloor?: boolean;
 }
 
+const GRADIENT_SUPPLY = 101;
+
 // Keep this Electron worker aligned with the renderer Arweave fallback order.
 const ARWEAVE_GATEWAYS: readonly string[] = [
   "arweave.net",
@@ -232,7 +234,7 @@ export const getEditionSizes = async (
   let burnt = await getBurns(db, contractAddress, tokenId);
   let editionSize;
   if (areEqualAddresses(contractAddress, GRADIENT_CONTRACT)) {
-    editionSize = await getIndexedErc721Supply(db, contractAddress, tokenId);
+    editionSize = GRADIENT_SUPPLY;
   } else if (areEqualAddresses(contractAddress, NEXTGEN_CONTRACT)) {
     const collectionId = Math.round(tokenId / 10000000000);
     const viewTokensIndexMin =
@@ -261,27 +263,6 @@ export const getEditionSizes = async (
     burnt,
   };
 };
-
-async function getIndexedErc721Supply(
-  db: DataSource,
-  contractAddress: string,
-  tokenId: number,
-) {
-  const contract = contractAddress.toLowerCase();
-  const repo = db.getRepository(NFT);
-  const indexedCount = await repo.count({
-    where: {
-      contract,
-    },
-  });
-  const tokenAlreadyIndexed = await repo.exist({
-    where: {
-      contract,
-      id: tokenId,
-    },
-  });
-  return tokenAlreadyIndexed ? indexedCount : indexedCount + 1;
-}
 
 async function resolveEditionSizeFloor(
   db: DataSource,

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
@@ -17,10 +17,7 @@ import {
 } from "../../../../shared/abis/memes";
 import { NEXTGEN_CONTRACT } from "../../../../shared/abis/nextgen";
 import { areEqualAddresses } from "../../../../shared/helpers";
-import {
-  getMemeEditionSizeFloor,
-  getCalculationEditionSize,
-} from "../../../../shared/memes-edition-size-floor";
+import { getMemeEditionSizeFloor } from "../../../../shared/memes-edition-size-floor";
 import { Time } from "../../../../shared/time";
 import { NFT } from "../../../db/entities/INFT";
 import { Transaction } from "../../../db/entities/ITransaction";
@@ -47,6 +44,7 @@ export interface EditionSizes {
 interface GetEditionSizesOptions {
   provider?: ethers.Provider;
   refreshEditionSizeFloor?: boolean;
+  backfillMissingEditionSizeFloor?: boolean;
 }
 
 // Keep this Electron worker aligned with the renderer Arweave fallback order.
@@ -304,7 +302,8 @@ async function resolveEditionSizeFloor(
 
   if (
     options.provider &&
-    (options.refreshEditionSizeFloor || existingFloor === null)
+    (options.refreshEditionSizeFloor ||
+      (options.backfillMissingEditionSizeFloor && existingFloor === null))
   ) {
     const onChainFloor = await fetchMemeEditionSizeFloorFromClaim(
       options.provider,
@@ -332,12 +331,12 @@ async function getExistingEditionSizeFloor(
       id: tokenId,
     },
   });
-  return (
-    getCalculationEditionSize({
-      actualSupply: 0,
-      editionSizeFloor: existing?.edition_size_floor,
-    }) || null
-  );
+  const existingFloor = existing?.edition_size_floor;
+  return typeof existingFloor === "number" &&
+    Number.isInteger(existingFloor) &&
+    existingFloor > 0
+    ? existingFloor
+    : null;
 }
 
 const MEMES_EDITION_SIZE_FLOOR_FETCH_TIMEOUT_MS = Time.seconds(10).toMillis();
@@ -388,36 +387,6 @@ async function withTimeout<T>(
       clearTimeout(timeout);
     }
   }
-}
-
-const MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS = Time.days(30).toMillis();
-
-export function getMemeTokenIdsForEditionSizeFloorRefresh(
-  nfts: Pick<NFT, "contract" | "id" | "mint_date">[],
-  nowMillis: number = Time.currentMillis(),
-): number[] {
-  const memes = nfts.filter((nft) =>
-    areEqualAddresses(nft.contract, MEMES_CONTRACT),
-  );
-  if (memes.length === 0) {
-    return [];
-  }
-
-  const refreshCutoff = nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS;
-  const latestMemeId = memes.reduce(
-    (latest, nft) => Math.max(latest, nft.id),
-    0,
-  );
-  const tokenIds = new Set<number>([latestMemeId]);
-
-  memes.forEach((nft) => {
-    const mintMillis = Number(nft.mint_date) * 1000;
-    if (Number.isFinite(mintMillis) && mintMillis >= refreshCutoff) {
-      tokenIds.add(nft.id);
-    }
-  });
-
-  return Array.from(tokenIds).sort((a, b) => a - b);
 }
 
 export const getMints = async (

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
@@ -8,11 +8,19 @@ import {
 } from "../../../../electron-constants";
 import { GRADIENT_CONTRACT } from "../../../../shared/abis/gradient";
 import {
+  MANIFOLD_LAZY_CLAIM_ABI,
+  MANIFOLD_LAZY_CLAIM_CONTRACT,
+} from "../../../../shared/abis/manifold";
+import {
   MEMELAB_CONTRACT,
   MEMES_CONTRACT,
 } from "../../../../shared/abis/memes";
 import { NEXTGEN_CONTRACT } from "../../../../shared/abis/nextgen";
 import { areEqualAddresses } from "../../../../shared/helpers";
+import {
+  getMemeEditionSizeFloor,
+  getCalculationEditionSize,
+} from "../../../../shared/memes-edition-size-floor";
 import { Time } from "../../../../shared/time";
 import { NFT } from "../../../db/entities/INFT";
 import { Transaction } from "../../../db/entities/ITransaction";
@@ -28,6 +36,17 @@ export interface Contract {
   address: string;
   abi: any;
   type: ContractType;
+}
+
+export interface EditionSizes {
+  editionSize: number;
+  editionSizeFloor: number;
+  burnt: number;
+}
+
+interface GetEditionSizesOptions {
+  provider?: ethers.Provider;
+  refreshEditionSizeFloor?: boolean;
 }
 
 // Keep this Electron worker aligned with the renderer Arweave fallback order.
@@ -128,7 +147,7 @@ export const retrieveNftFromURI = async (
   contract: string,
   tokenId: number,
   uri: string,
-  editionSizes: { editionSize: number; burnt: number },
+  editionSizes: EditionSizes,
 ): Promise<NFT> => {
   logInfo(
     parentPort,
@@ -155,6 +174,7 @@ export const retrieveNftFromURI = async (
     full_metadata: json,
     mint_date: mintDate,
     edition_size: editionSizes.editionSize,
+    edition_size_floor: editionSizes.editionSizeFloor,
     burns: editionSizes.burnt,
     name: json.name,
     description: json.description,
@@ -209,11 +229,12 @@ export const getEditionSizes = async (
   contractAddress: string,
   ethersContract: ethers.Contract,
   tokenId: number,
+  options: GetEditionSizesOptions = {},
 ) => {
   let burnt = await getBurns(db, contractAddress, tokenId);
   let editionSize;
   if (areEqualAddresses(contractAddress, GRADIENT_CONTRACT)) {
-    editionSize = 101;
+    editionSize = await getIndexedErc721Supply(db, contractAddress, tokenId);
   } else if (areEqualAddresses(contractAddress, NEXTGEN_CONTRACT)) {
     const collectionId = Math.round(tokenId / 10000000000);
     const viewTokensIndexMin =
@@ -228,12 +249,172 @@ export const getEditionSizes = async (
       burnt += MEME_8_EDITION_BURN_ADJUSTMENT;
     }
   }
+  const editionSizeFloor = await resolveEditionSizeFloor(
+    db,
+    contractAddress,
+    tokenId,
+    editionSize,
+    options,
+  );
 
   return {
     editionSize,
+    editionSizeFloor,
     burnt,
   };
 };
+
+async function getIndexedErc721Supply(
+  db: DataSource,
+  contractAddress: string,
+  tokenId: number,
+) {
+  const contract = contractAddress.toLowerCase();
+  const repo = db.getRepository(NFT);
+  const indexedCount = await repo.count({
+    where: {
+      contract,
+    },
+  });
+  const tokenAlreadyIndexed = await repo.exist({
+    where: {
+      contract,
+      id: tokenId,
+    },
+  });
+  return tokenAlreadyIndexed ? indexedCount : indexedCount + 1;
+}
+
+async function resolveEditionSizeFloor(
+  db: DataSource,
+  contractAddress: string,
+  tokenId: number,
+  actualSupply: number,
+  options: GetEditionSizesOptions,
+) {
+  if (!areEqualAddresses(contractAddress, MEMES_CONTRACT)) {
+    return actualSupply;
+  }
+
+  if (options.refreshEditionSizeFloor && options.provider) {
+    const onChainFloor = await fetchMemeEditionSizeFloorFromClaim(
+      options.provider,
+      tokenId,
+    );
+    if (onChainFloor !== null) {
+      return onChainFloor;
+    }
+  }
+
+  const existingFloor = await getExistingEditionSizeFloor(
+    db,
+    contractAddress,
+    tokenId,
+  );
+  return existingFloor ?? actualSupply;
+}
+
+async function getExistingEditionSizeFloor(
+  db: DataSource,
+  contractAddress: string,
+  tokenId: number,
+) {
+  const existing = await db.getRepository(NFT).findOne({
+    select: {
+      edition_size_floor: true,
+    },
+    where: {
+      contract: contractAddress.toLowerCase(),
+      id: tokenId,
+    },
+  });
+  return (
+    getCalculationEditionSize({
+      actualSupply: 0,
+      editionSizeFloor: existing?.edition_size_floor,
+    }) || null
+  );
+}
+
+const MEMES_EDITION_SIZE_FLOOR_FETCH_TIMEOUT_MS = Time.seconds(10).toMillis();
+
+async function fetchMemeEditionSizeFloorFromClaim(
+  provider: ethers.Provider,
+  tokenId: number,
+) {
+  try {
+    const contract = new ethers.Contract(
+      MANIFOLD_LAZY_CLAIM_CONTRACT,
+      MANIFOLD_LAZY_CLAIM_ABI,
+      provider,
+    );
+    const claimResult = (await withTimeout(
+      contract.getClaimForToken(MEMES_CONTRACT, tokenId),
+      MEMES_EDITION_SIZE_FLOOR_FETCH_TIMEOUT_MS,
+      `Timed out fetching Manifold totalMax for Meme #${tokenId}`,
+    )) as { claim?: { totalMax?: unknown }; [index: number]: unknown };
+    const claim =
+      claimResult.claim ??
+      (claimResult[1] as { totalMax?: unknown } | null | undefined);
+    return getMemeEditionSizeFloor(claim?.totalMax);
+  } catch (error) {
+    logInfo(
+      parentPort,
+      `Failed to fetch Manifold totalMax for Meme #${tokenId}`,
+      error,
+    );
+    return null;
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+const MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS = Time.days(30).toMillis();
+
+export function getMemeTokenIdsForEditionSizeFloorRefresh(
+  nfts: Pick<NFT, "contract" | "id" | "mint_date">[],
+  nowMillis: number = Time.currentMillis(),
+): number[] {
+  const memes = nfts.filter((nft) =>
+    areEqualAddresses(nft.contract, MEMES_CONTRACT),
+  );
+  if (memes.length === 0) {
+    return [];
+  }
+
+  const refreshCutoff = nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS;
+  const latestMemeId = memes.reduce(
+    (latest, nft) => Math.max(latest, nft.id),
+    0,
+  );
+  const tokenIds = new Set<number>([latestMemeId]);
+
+  memes.forEach((nft) => {
+    const mintMillis = Number(nft.mint_date) * 1000;
+    if (Number.isFinite(mintMillis) && mintMillis >= refreshCutoff) {
+      tokenIds.add(nft.id);
+    }
+  });
+
+  return Array.from(tokenIds).sort((a, b) => a - b);
+}
 
 export const getMints = async (
   db: DataSource,

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
@@ -296,7 +296,16 @@ async function resolveEditionSizeFloor(
     return actualSupply;
   }
 
-  if (options.refreshEditionSizeFloor && options.provider) {
+  const existingFloor = await getExistingEditionSizeFloor(
+    db,
+    contractAddress,
+    tokenId,
+  );
+
+  if (
+    options.provider &&
+    (options.refreshEditionSizeFloor || existingFloor === null)
+  ) {
     const onChainFloor = await fetchMemeEditionSizeFloorFromClaim(
       options.provider,
       tokenId,
@@ -306,11 +315,6 @@ async function resolveEditionSizeFloor(
     }
   }
 
-  const existingFloor = await getExistingEditionSizeFloor(
-    db,
-    contractAddress,
-    tokenId,
-  );
   return existingFloor ?? actualSupply;
 }
 

--- a/electron-src/scheduled-tasks/workers/tdh-worker/tdh.ts
+++ b/electron-src/scheduled-tasks/workers/tdh-worker/tdh.ts
@@ -17,6 +17,10 @@ import { GRADIENT_CONTRACT } from "../../../../shared/abis/gradient";
 import { MEMES_CONTRACT } from "../../../../shared/abis/memes";
 import { NEXTGEN_CONTRACT } from "../../../../shared/abis/nextgen";
 import { areEqualAddresses, getDaysDiff } from "../../../../shared/helpers";
+import {
+  calculateHodlRate,
+  getCalculationEditionSize,
+} from "../../../../shared/memes-edition-size-floor";
 import * as numbers from "../../../../shared/numbers";
 import { Time } from "../../../../shared/time";
 import { ScheduledWorkerStatus } from "../../../../shared/types";
@@ -46,6 +50,17 @@ interface MemesSeason {
   boost: number;
 }
 
+function getNftCalculationKey(nft: Pick<NFT, "contract" | "id">): string {
+  return `${nft.contract.toLowerCase()}-${nft.id}`;
+}
+
+function getNftCalculationEditionSize(nft: NFT): number {
+  return getCalculationEditionSize({
+    actualSupply: nft.edition_size,
+    editionSizeFloor: nft.edition_size_floor,
+  });
+}
+
 export const ADDITIONAL_CARD_SET_BOOST = 0.05;
 export const ADDITIONAL_CARD_SET_RATIO = 0.6529;
 
@@ -61,7 +76,7 @@ function getBoostableSeasons(seasons: MemesSeason[]): MemesSeason[] {
 
 function getFullCollectionSetBoost(seasons: MemesSeason[]): number {
   return roundBoostValue(
-    getBoostableSeasons(seasons).reduce((sum, season) => sum + season.boost, 0)
+    getBoostableSeasons(seasons).reduce((sum, season) => sum + season.boost, 0),
   );
 }
 
@@ -73,18 +88,18 @@ function getAdditionalCardSetsBoost(additionalCardSets: number): number {
   return roundBoostValue(
     (ADDITIONAL_CARD_SET_BOOST *
       (1 - Math.pow(ADDITIONAL_CARD_SET_RATIO, additionalCardSets))) /
-      (1 - ADDITIONAL_CARD_SET_RATIO)
+      (1 - ADDITIONAL_CARD_SET_RATIO),
   );
 }
 
 function getAdditionalCardSetsBoostLimit(): number {
   return roundBoostValue(
-    ADDITIONAL_CARD_SET_BOOST / (1 - ADDITIONAL_CARD_SET_RATIO)
+    ADDITIONAL_CARD_SET_BOOST / (1 - ADDITIONAL_CARD_SET_RATIO),
   );
 }
 
 export function consolidateTransactions(
-  transactions: BaseTransaction[]
+  transactions: BaseTransaction[],
 ): BaseTransaction[] {
   const consolidatedTransactions: BaseTransaction[] = Object.values(
     transactions.reduce((acc: any, transaction) => {
@@ -95,7 +110,7 @@ export function consolidateTransactions(
       }
 
       return acc;
-    }, {})
+    }, {}),
   );
   return consolidatedTransactions;
 }
@@ -105,7 +120,7 @@ export function getDefaultBoost(seasons: MemesSeason[] = []): DefaultBoost {
   const boost: DefaultBoost = {
     memes_card_sets: {
       available: roundBoostValue(
-        fullCollectionSetBoost + getAdditionalCardSetsBoostLimit()
+        fullCollectionSetBoost + getAdditionalCardSetsBoostLimit(),
       ),
       available_info: [
         `${fullCollectionSetBoost} for Full Collection Set`,
@@ -161,7 +176,7 @@ export function createMemesData() {
 export const buildSeasons = (memes: NFT[]): MemesSeason[] => {
   const seasonIds = [
     ...new Set(
-      memes.map((m) => m.season).filter((s): s is number => s != null)
+      memes.map((m) => m.season).filter((s): s is number => s != null),
     ),
   ];
   return seasonIds.map((id) => {
@@ -181,11 +196,11 @@ export const calculateTDH = async (
   block: number,
   lastTDHCalc: Date,
   blockTimestamp: Time,
-  startingWallets?: string[]
+  startingWallets?: string[],
 ): Promise<{ block: number; merkleRoot: string }> => {
   logInfo(
     parentPort,
-    `[BLOCK ${block}] [TDH TIME ${lastTDHCalc.toLocaleString()}]`
+    `[BLOCK ${block}] [TDH TIME ${lastTDHCalc.toLocaleString()}]`,
   );
   if (startingWallets) {
     logInfo(parentPort, `[STARTING WALLETS ${startingWallets.length}]`);
@@ -205,13 +220,13 @@ export const calculateTDH = async (
   logInfo(parentPort, `[OWNERS ${owners.length}]`);
 
   const memeOwners = owners.filter((o) =>
-    areEqualAddresses(o.contract, MEMES_CONTRACT)
+    areEqualAddresses(o.contract, MEMES_CONTRACT),
   );
   const gradientOwners = owners.filter((o) =>
-    areEqualAddresses(o.contract, GRADIENT_CONTRACT)
+    areEqualAddresses(o.contract, GRADIENT_CONTRACT),
   );
   const nextgenOwners = owners.filter((o) =>
-    areEqualAddresses(o.contract, NEXTGEN_CONTRACT)
+    areEqualAddresses(o.contract, NEXTGEN_CONTRACT),
   );
 
   const nftRepository = db.getRepository(NFT);
@@ -235,7 +250,7 @@ export const calculateTDH = async (
     .filter(
       (m) =>
         m.mint_date &&
-        Time.seconds(m.mint_date).lte(Time.fromDate(lastTDHCalc).minusDays(1))
+        Time.seconds(m.mint_date).lte(Time.fromDate(lastTDHCalc).minusDays(1)),
     )
     .map((m) => {
       const tokenOwners = memeOwners.filter((o) => o.token_id === m.id);
@@ -243,7 +258,14 @@ export const calculateTDH = async (
       if (m.id === 8) {
         editionSize += MEME_8_EDITION_BURN_ADJUSTMENT;
       }
-      logInfo(parentPort, `[MEME ${m.id}] [EDITION SIZE ${editionSize}]`);
+      const calculationEditionSize = getCalculationEditionSize({
+        actualSupply: editionSize,
+        editionSizeFloor: m.edition_size_floor,
+      });
+      logInfo(
+        parentPort,
+        `[MEME ${m.id}] [EDITION SIZE ${editionSize}] [CALCULATION EDITION SIZE ${calculationEditionSize}]`,
+      );
       return { ...m, edition_size: editionSize };
     });
   memes.sort((a, b) => a.id - b.id);
@@ -252,21 +274,27 @@ export const calculateTDH = async (
 
   logInfo(
     parentPort,
-    `[MEMES] : [TOKENS ${memes.length}] : [OWNERS ${memeOwners.length}] : [SEASONS ${ADJUSTED_SEASONS.length}]`
+    `[MEMES] : [TOKENS ${memes.length}] : [OWNERS ${memeOwners.length}] : [SEASONS ${ADJUSTED_SEASONS.length}]`,
   );
   logInfo(
     parentPort,
-    `[GRADIENTS] : [TOKENS ${gradients.length}] : [OWNERS ${gradientOwners.length}]`
+    `[GRADIENTS] : [TOKENS ${gradients.length}] : [OWNERS ${gradientOwners.length}]`,
   );
   logInfo(
     parentPort,
-    `[NEXTGEN] : [TOKENS ${nextgen.length}] : [OWNERS ${nextgenOwners.length}]`
+    `[NEXTGEN] : [TOKENS ${nextgen.length}] : [OWNERS ${nextgenOwners.length}]`,
   );
 
   const ADJUSTED_NFTS = [...memes, ...gradients, ...nextgen];
-  const HODL_INDEX = ADJUSTED_NFTS.reduce(
-    (acc, m) => Math.max(acc, m.edition_size),
-    0
+  const CALCULATION_EDITION_SIZES = new Map(
+    ADJUSTED_NFTS.map((nft) => [
+      getNftCalculationKey(nft),
+      getNftCalculationEditionSize(nft),
+    ]),
+  );
+  const HODL_INDEX = Array.from(CALCULATION_EDITION_SIZES.values()).reduce(
+    (acc, calculationEditionSize) => Math.max(acc, calculationEditionSize),
+    0,
   );
   logInfo(parentPort, `[HODL_INDEX ${HODL_INDEX}]`);
 
@@ -279,7 +307,7 @@ export const calculateTDH = async (
     const consolidationAddresses: { wallet: string }[] =
       await fetchAllConsolidationAddresses(db);
     consolidationAddresses.forEach((w) =>
-      combinedAddresses.add(w.wallet.toLowerCase())
+      combinedAddresses.add(w.wallet.toLowerCase()),
     );
 
     owners.forEach((w) => combinedAddresses.add(w.address.toLowerCase()));
@@ -287,7 +315,7 @@ export const calculateTDH = async (
 
   logInfo(
     parentPort,
-    `[BLOCK ${block}] [WALLETS ${combinedAddresses.size}] [CALCULATING TDH - START]`
+    `[BLOCK ${block}] [WALLETS ${combinedAddresses.size}] [CALCULATING TDH - START]`,
   );
   sendStatusUpdate(parentPort, {
     update: {
@@ -330,20 +358,20 @@ export const calculateTDH = async (
             db,
             TDH_CONTRACTS,
             c,
-            block
+            block,
           );
           consolidationTransactions =
             consolidationTransactions.concat(transactions);
-        })
+        }),
       );
 
       consolidationTransactions = consolidateTransactions(
-        consolidationTransactions
+        consolidationTransactions,
       ).sort((a, b) => a.transaction_date - b.transaction_date);
 
       if (areEqualAddresses(wallet, NULL_ADDRESS)) {
         consolidationTransactions = consolidationTransactions.filter(
-          (t) => !areEqualAddresses(t.transaction, MEME_8_BURN_TRANSACTION)
+          (t) => !areEqualAddresses(t.transaction, MEME_8_BURN_TRANSACTION),
         );
       }
 
@@ -354,10 +382,13 @@ export const calculateTDH = async (
           (t) =>
             t.token_id == nft.id &&
             areEqualAddresses(t.contract, nft.contract) &&
-            !areEqualAddresses(t.from_address, t.to_address)
+            !areEqualAddresses(t.from_address, t.to_address),
         );
 
-        const hodlRate = HODL_INDEX / nft.edition_size;
+        const calculationEditionSize =
+          CALCULATION_EDITION_SIZES.get(getNftCalculationKey(nft)) ??
+          getNftCalculationEditionSize(nft);
+        const hodlRate = calculateHodlRate(HODL_INDEX, calculationEditionSize);
 
         const tokenTDH = getTokenTdh(
           lastTDHCalc,
@@ -365,7 +396,7 @@ export const calculateTDH = async (
           hodlRate,
           wallet,
           consolidations,
-          tokenConsolidatedTransactions
+          tokenConsolidatedTransactions,
         );
 
         if (tokenTDH) {
@@ -398,7 +429,7 @@ export const calculateTDH = async (
         memesCardSets = Math.min(
           ...[...walletMemes].map(function (o) {
             return o.balance;
-          })
+          }),
         );
       }
 
@@ -448,12 +479,12 @@ export const calculateTDH = async (
         allNextgenTDH.push(wn);
       });
       walletsTDH.push(tdh);
-    })
+    }),
   );
 
   logInfo(
     parentPort,
-    `[BLOCK ${block}] [WALLETS ${combinedAddresses.size}] [CALCULATING BOOSTS]`
+    `[BLOCK ${block}] [WALLETS ${combinedAddresses.size}] [CALCULATING BOOSTS]`,
   );
   sendStatusUpdate(parentPort, {
     update: {
@@ -470,30 +501,30 @@ export const calculateTDH = async (
     const allTdh = allCurrentTdh
       .filter(
         (t: TDH) =>
-          !startingWallets.some((sw) => areEqualAddresses(sw, t.wallet))
+          !startingWallets.some((sw) => areEqualAddresses(sw, t.wallet)),
       )
       .concat(boostedTdh);
     const allRankedTdh = await calculateRanks(
       allGradientsTDH,
       allNextgenTDH,
       allTdh,
-      ADJUSTED_NFTS
+      ADJUSTED_NFTS,
     );
     rankedTdh = allRankedTdh.filter((t: TDH) =>
-      startingWallets.some((sw) => areEqualAddresses(sw, t.wallet))
+      startingWallets.some((sw) => areEqualAddresses(sw, t.wallet)),
     );
   } else {
     rankedTdh = await calculateRanks(
       allGradientsTDH,
       allNextgenTDH,
       boostedTdh,
-      ADJUSTED_NFTS
+      ADJUSTED_NFTS,
     );
   }
 
   logInfo(
     parentPort,
-    `[BLOCK ${block}] [WALLETS ${rankedTdh.length}] [UPDATING DATABASE]`
+    `[BLOCK ${block}] [WALLETS ${rankedTdh.length}] [UPDATING DATABASE]`,
   );
   sendStatusUpdate(parentPort, {
     update: {
@@ -506,7 +537,7 @@ export const calculateTDH = async (
 
   logInfo(
     parentPort,
-    `[BLOCK ${block}] [WALLETS ${rankedTdh.length}] [DATABASE UPDATED]`
+    `[BLOCK ${block}] [WALLETS ${rankedTdh.length}] [DATABASE UPDATED]`,
   );
   sendStatusUpdate(parentPort, {
     update: {
@@ -529,14 +560,14 @@ export const calculateTDH = async (
 function hasSeasonSet(
   seasonId: number,
   seasons: MemesSeason[],
-  memes: TokenTDH[]
+  memes: TokenTDH[],
 ): boolean {
   const season = seasons.find((s) => s.id == seasonId);
   if (!season) {
     return false;
   }
   const seasonMemes = memes.filter(
-    (m) => m.id >= season.start_index && m.id <= season.end_index
+    (m) => m.id >= season.start_index && m.id <= season.end_index,
   );
 
   return seasonMemes.length === season.count;
@@ -544,7 +575,7 @@ function hasSeasonSet(
 
 function calculateMemesBoostsCardSets(
   cardSets: number,
-  seasons: MemesSeason[]
+  seasons: MemesSeason[],
 ) {
   let boost = 1;
   const breakdown = getDefaultBoost(seasons);
@@ -554,7 +585,7 @@ function calculateMemesBoostsCardSets(
   const additionalCardSets = Math.max(0, cardSets - 1);
   const additionalIncrement = getAdditionalCardSetsBoost(additionalCardSets);
   const roundedCombinedBoost = roundBoostValue(
-    fullSetBoost + additionalIncrement
+    fullSetBoost + additionalIncrement,
   );
 
   boost += roundedCombinedBoost;
@@ -566,7 +597,7 @@ function calculateMemesBoostsCardSets(
   } else if (additionalCardSets > 1) {
     const incStr = additionalIncrement.toString();
     acquiredInfo.push(
-      `${incStr} total for ${additionalCardSets} additional sets (${ADDITIONAL_CARD_SET_BOOST} * (1 - ${ADDITIONAL_CARD_SET_RATIO}^${additionalCardSets}) / (1 - ${ADDITIONAL_CARD_SET_RATIO}))`
+      `${incStr} total for ${additionalCardSets} additional sets (${ADDITIONAL_CARD_SET_BOOST} * (1 - ${ADDITIONAL_CARD_SET_RATIO}^${additionalCardSets}) / (1 - ${ADDITIONAL_CARD_SET_RATIO}))`,
     );
   }
   breakdown.memes_card_sets.acquired_info = acquiredInfo;
@@ -583,7 +614,7 @@ function calculateMemesBoostsSeasons(
     genesis: number;
     nakamoto: number;
   },
-  memes: TokenTDH[]
+  memes: TokenTDH[],
 ) {
   let boost = 1;
   const seasonsForBoost = getBoostableSeasons(seasons);
@@ -640,7 +671,7 @@ function calculateMemesBoosts(
     genesis: number;
     nakamoto: number;
   },
-  memes: TokenTDH[]
+  memes: TokenTDH[],
 ) {
   if (cardSets > 0) {
     return calculateMemesBoostsCardSets(cardSets, seasons);
@@ -657,7 +688,7 @@ export function calculateBoost(
     nakamoto: number;
   },
   memes: TokenTDH[],
-  gradients: any[]
+  gradients: any[],
 ) {
   const memesBoosts = calculateMemesBoosts(cardSets, seasons, s1Extra, memes);
 
@@ -691,12 +722,12 @@ function getTokenTdh(
   hodlRate: number,
   wallet: string,
   consolidations: string[],
-  tokenConsolidatedTransactions: Transaction[]
+  tokenConsolidatedTransactions: Transaction[],
 ): TokenTDH | null {
   const tokenDatesForWallet = getTokenDatesFromConsolidation(
     wallet,
     consolidations,
-    tokenConsolidatedTransactions
+    tokenConsolidatedTransactions,
   );
 
   let tdh__raw = 0;
@@ -731,7 +762,7 @@ function getTokenTdh(
 function getTokenDatesFromConsolidation(
   currentWallet: string,
   consolidations: string[],
-  consolidationTransactions: Transaction[]
+  consolidationTransactions: Transaction[],
 ) {
   const tokenDatesMap: { [wallet: string]: Date[] } = {};
 
@@ -748,12 +779,12 @@ function getTokenDatesFromConsolidation(
         "hi i am wallet",
         wallet,
         tokenDatesMap,
-        consolidationTransactions
+        consolidationTransactions,
       );
     }
     const removeDates = tokenDatesMap[wallet].splice(
       tokenDatesMap[wallet].length - count,
-      count
+      count,
     );
     return removeDates;
   }
@@ -769,16 +800,16 @@ function getTokenDatesFromConsolidation(
       consolidations.some(
         (c) =>
           !areEqualAddresses(c, currentWallet) &&
-          areEqualAddresses(c, a.from_address)
-      )
+          areEqualAddresses(c, a.from_address),
+      ),
     );
 
     const bInConsolidations = Number(
       consolidations.some(
         (c) =>
           !areEqualAddresses(c, currentWallet) &&
-          areEqualAddresses(c, b.from_address)
-      )
+          areEqualAddresses(c, b.from_address),
+      ),
     );
 
     if (aInConsolidations || bInConsolidations) {
@@ -806,7 +837,7 @@ function getTokenDatesFromConsolidation(
       if (!consolidations.some((c) => areEqualAddresses(c, from_address))) {
         addDates(
           to_address,
-          Array.from({ length: token_count }, () => trDate)
+          Array.from({ length: token_count }, () => trDate),
         );
       } else {
         const removedDates = removeDates(from_address, token_count);
@@ -825,7 +856,7 @@ function getTokenDatesFromConsolidation(
 
 export async function calculateBoosts(
   seasons: MemesSeason[],
-  walletsTDH: any[]
+  walletsTDH: any[],
 ) {
   const boostedTDH: any[] = [];
 
@@ -839,22 +870,22 @@ export async function calculateBoosts(
           nakamoto: w.nakamoto,
         },
         w.memes,
-        w.gradients
+        w.gradients,
       );
 
       const boost = boostBreakdown.total;
 
       const boostedMemesTdh = w.memes.reduce(
         (sum: number, m: TokenTDH) => sum + Math.round(m.tdh * boost),
-        0
+        0,
       );
       const boostedGradientsTdh = w.gradients.reduce(
         (sum: number, g: any) => sum + Math.round(g.tdh * boost),
-        0
+        0,
       );
       const boostedNextgenTdh = w.nextgen.reduce(
         (sum: number, n: any) => sum + Math.round(n.tdh * boost),
-        0
+        0,
       );
 
       const boostedTdh =
@@ -870,7 +901,7 @@ export async function calculateBoosts(
       w.boosted_nextgen_tdh = boostedNextgenTdh;
 
       boostedTDH.push(w);
-    })
+    }),
   );
 
   return boostedTDH;
@@ -880,7 +911,7 @@ export async function calculateRanks(
   allGradientsTDH: any[],
   allNextgenTDH: any[],
   boostedTDH: any[],
-  ADJUSTED_NFTS: any[]
+  ADJUSTED_NFTS: any[],
 ) {
   allGradientsTDH.sort((a, b) => b.tdh - a.tdh || a.id - b.id || -1);
   const rankedGradientsTdh = allGradientsTDH.map((a, index) => {
@@ -901,7 +932,7 @@ export async function calculateRanks(
           (areEqualAddresses(nft.contract, MEMES_CONTRACT) &&
             w.memes.some((m: any) => m.id == nft.id)) ||
           (areEqualAddresses(nft.contract, GRADIENT_CONTRACT) &&
-            w.gradients_tdh > 0)
+            w.gradients_tdh > 0),
       )
       .sort((a, b) => {
         const aNftBalance = areEqualAddresses(nft.contract, MEMES_CONTRACT)
@@ -954,7 +985,7 @@ export async function calculateRanks(
 
     if (areEqualAddresses(nft.contract, MEMES_CONTRACT)) {
       const wallets = [...boostedTDH].filter((w) =>
-        w.memes.some((m: any) => m.id == nft.id)
+        w.memes.some((m: any) => m.id == nft.id),
       );
 
       wallets.sort((a, b) => {
@@ -1069,7 +1100,7 @@ export function getGenesisAndNaka(memes: TokenTDH[]) {
 
 export async function findLatestBlockBeforeTimestamp(
   provider: ethers.JsonRpcProvider,
-  targetTimestamp: number
+  targetTimestamp: number,
 ) {
   logInfo(parentPort, "Finding latest block before timestamp", targetTimestamp);
   const averageBlockTime = 12; // Approximate average block time in seconds
@@ -1081,7 +1112,7 @@ export async function findLatestBlockBeforeTimestamp(
   let startBlock = Math.max(
     0,
     latestBlock.number -
-      Math.floor((latestBlock.timestamp - targetTimestamp) / averageBlockTime)
+      Math.floor((latestBlock.timestamp - targetTimestamp) / averageBlockTime),
   );
   let endBlock = latestBlock.number;
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dist-linux-staging": "node scripts/require-6529-command.cjs && node scripts/desktop-build-target.cjs dist-linux-staging",
     "dist-linux-production": "node scripts/require-6529-command.cjs && node scripts/desktop-build-target.cjs dist-linux-production",
     "type-check": "node scripts/require-6529-command.cjs && tsc -p ./renderer/tsconfig.typecheck.json && tsc -p ./electron-src/tsconfig.json",
+    "test:shared": "node scripts/require-6529-command.cjs && tsx --test \"shared/**/*.test.ts\"",
     "publish-links-staging": "node scripts/require-6529-command.cjs && tsx scripts/publish-links.ts --staging --skip-arweave",
     "publish-links-staging-arweave": "node scripts/require-6529-command.cjs && tsx scripts/publish-links.ts --staging",
     "publish-links-production": "node scripts/require-6529-command.cjs && tsx scripts/publish-links.ts --skip-arweave",

--- a/renderer/__tests__/helpers/notification.helpers.test.ts
+++ b/renderer/__tests__/helpers/notification.helpers.test.ts
@@ -1,0 +1,84 @@
+import { ApiNotificationCause } from "@/generated/models/ApiNotificationCause";
+import { generateNotificationData } from "@/helpers/notification.helpers";
+import type { ApiNotification } from "@/generated/models/ApiNotification";
+
+const createDropReactedNotification = (
+  reaction: string
+): ApiNotification =>
+  ({
+    id: 1,
+    cause: ApiNotificationCause.DropReacted,
+    created_at: 1,
+    read_at: null,
+    related_identity: {
+      handle: "prxt0",
+    },
+    related_drops: [
+      {
+        serial_no: 7,
+        wave: {
+          id: "wave-1",
+        },
+        parts: [
+          {
+            content: "gm",
+          },
+        ],
+      },
+    ],
+    additional_context: {
+      reaction,
+    },
+  }) as ApiNotification;
+
+const emptyEmojiResolvers = {
+  findNativeEmoji: () => null,
+  findCustomEmoji: () => null,
+};
+
+describe("generateNotificationData", () => {
+  it("renders native reaction shortcodes as emoji glyphs", () => {
+    const data = generateNotificationData(
+      createDropReactedNotification(":white_check_mark:"),
+      emptyEmojiResolvers
+    );
+
+    expect(data?.title).toBe("prxt0 reacted ✅");
+    expect(data?.body).toBe("gm");
+  });
+
+  it("normalizes hyphenated native reaction ids before rendering glyphs", () => {
+    const data = generateNotificationData(
+      createDropReactedNotification("white-check-mark"),
+      emptyEmojiResolvers
+    );
+
+    expect(data?.title).toBe("prxt0 reacted ✅");
+  });
+
+  it("returns custom reaction emoji images as notification icons", () => {
+    const data = generateNotificationData(
+      createDropReactedNotification(":sgt_wink:"),
+      {
+        findNativeEmoji: () => null,
+        findCustomEmoji: (emojiId: string) =>
+          emojiId === "sgt_wink"
+            ? { skins: [{ src: "https://example.test/sgt_wink.webp" }] }
+            : null,
+      }
+    );
+
+    expect(data?.title).toBe("prxt0 reacted");
+    expect(data?.iconUrl).toBe("https://example.test/sgt_wink.webp");
+  });
+
+  it("falls back to readable text for unknown reactions", () => {
+    const data = generateNotificationData(
+      createDropReactedNotification(":unknown_reaction:"),
+      emptyEmojiResolvers
+    );
+
+    expect(data?.title).toBe("prxt0 reacted 'unknown reaction'");
+    expect(data?.iconUrl).toBeUndefined();
+  });
+});

--- a/renderer/__tests__/helpers/notification.helpers.test.ts
+++ b/renderer/__tests__/helpers/notification.helpers.test.ts
@@ -56,6 +56,15 @@ describe("generateNotificationData", () => {
     expect(data?.title).toBe("prxt0 reacted ✅");
   });
 
+  it("renders raw emoji character reactions as-is", () => {
+    const data = generateNotificationData(
+      createDropReactedNotification("✅"),
+      emptyEmojiResolvers
+    );
+
+    expect(data?.title).toBe("prxt0 reacted ✅");
+  });
+
   it("returns custom reaction emoji images as notification icons", () => {
     const data = generateNotificationData(
       createDropReactedNotification(":sgt_wink:"),

--- a/renderer/components/core/eth-scanner/Workers.tsx
+++ b/renderer/components/core/eth-scanner/Workers.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/shared/ConfirmModalShell";
 import { useToast } from "@/contexts/ToastContext";
 import {
+  fullRefreshWorker,
   manualStartWorker,
   recalculateTransactionsOwners,
   resetTransactionsToBlock,
@@ -245,6 +246,8 @@ export function WorkerCard({
   const [showResetToBlockConfirm, setShowResetToBlockConfirm] = useState(false);
   const [showRecalculateOwnersConfirm, setShowRecalculateOwnersConfirm] =
     useState(false);
+  const [showFullRefreshNFTsConfirm, setShowFullRefreshNFTsConfirm] =
+    useState(false);
   const [showResetWorkerConfirm, setShowResetWorkerConfirm] = useState(false);
   const [showResetNFTsConfirm, setShowResetNFTsConfirm] = useState(false);
   const [showRunNowConfirm, setShowRunNowConfirm] = useState(false);
@@ -296,6 +299,14 @@ export function WorkerCard({
         showToast(data.data, data.error ? "error" : "success");
       })
       .finally(() => setShowRunNowConfirm(false));
+  };
+
+  const triggerFullRefreshWorker = async () => {
+    fullRefreshWorker(task.namespace)
+      .then((data) => {
+        showToast(data.data, data.error ? "error" : "success");
+      })
+      .finally(() => setShowFullRefreshNFTsConfirm(false));
   };
 
   const triggerStopWorker = async () => {
@@ -373,6 +384,19 @@ export function WorkerCard({
                 Run Now
               </button>
             )}
+        {task.namespace === ScheduledWorkerNames.NFTS_WORKER &&
+          infoButton(
+            "full-refresh-nfts-tooltip",
+            <button
+              type="button"
+              className={btnLight}
+              data-tooltip-id="full-refresh-nfts-tooltip"
+              disabled={task.status?.status === ScheduledWorkerStatus.RUNNING}
+              onClick={() => setShowFullRefreshNFTsConfirm(true)}
+            >
+              Full Refresh
+            </button>,
+          )}
         {task.resetable &&
           infoButton(
             "reset-worker-tooltip",
@@ -492,6 +516,13 @@ export function WorkerCard({
         onConfirm={triggerRecalculateTransactionsOwners}
         title="Recalculate Owners"
         message={`Roll back the transactions database by 5,000 block, then re-process all NFT transactions stored in the local database and recalculates ownership and balances for each owner, ensuring accurate and up-to-date data for every token based on the transaction history. Use this if discrepancies in ownership or balance are detected.`}
+      />
+      <Confirm
+        show={showFullRefreshNFTsConfirm}
+        onHide={() => setShowFullRefreshNFTsConfirm(false)}
+        onConfirm={triggerFullRefreshWorker}
+        title="Full Refresh NFTs"
+        message={`Refresh all indexed NFTs from chain and metadata without deleting local NFT data.`}
       />
       <Confirm
         show={showResetWorkerConfirm}

--- a/renderer/components/notifications/DesktopNotificationsBridge.tsx
+++ b/renderer/components/notifications/DesktopNotificationsBridge.tsx
@@ -96,7 +96,7 @@ export default function DesktopNotificationsBridge() {
   const router = useRouter();
   const pathname = usePathname();
   const { connectedProfile } = useAuth();
-  const { findNativeEmoji } = useEmoji();
+  const { findCustomEmoji, findNativeEmoji, loadEmojiData } = useEmoji();
   const {
     address,
     connectedAccounts,
@@ -129,6 +129,14 @@ export default function DesktopNotificationsBridge() {
       ),
     [connectedAccountUnreadNotifications]
   );
+
+  useEffect(() => {
+    if (!isElectron()) {
+      return;
+    }
+
+    void loadEmojiData();
+  }, [loadEmojiData]);
 
   useEffect(() => {
     if (!isElectron()) {
@@ -321,14 +329,18 @@ export default function DesktopNotificationsBridge() {
       const relatedPfp = notification.related_identity?.pfp;
       const notificationData = generateNotificationData(
         notification,
-        findNativeEmoji,
+        {
+          findNativeEmoji,
+          findCustomEmoji,
+        },
         accountHandle || null
       );
       if (!notificationData) {
         return;
       }
 
-      const icon = relatedPfp ? await resolveIpfsUrlAsync(relatedPfp) : "";
+      const iconSource = notificationData.iconUrl ?? relatedPfp;
+      const icon = iconSource ? await resolveIpfsUrlAsync(iconSource) : "";
       window.notifications.showNotification(
         notification.id,
         icon,
@@ -342,7 +354,7 @@ export default function DesktopNotificationsBridge() {
         }
       );
     },
-    [findNativeEmoji]
+    [findCustomEmoji, findNativeEmoji]
   );
 
   const pollNotifications = useCallback(async () => {

--- a/renderer/electron.ts
+++ b/renderer/electron.ts
@@ -85,7 +85,7 @@ export async function manualStartWorker(namespace: string) {
 }
 
 export async function fullRefreshWorker(namespace: string) {
-  const data = await window.api.sendSync(FULL_REFRESH_WORKER, namespace);
+  const data = await window.api.invoke(FULL_REFRESH_WORKER, namespace);
   return data;
 }
 

--- a/renderer/electron.ts
+++ b/renderer/electron.ts
@@ -5,6 +5,7 @@ import {
   DEACTIVATE_RPC_PROVIDER,
   DELETE_RPC_PROVIDER,
   DELETE_SEED_WALLET,
+  FULL_REFRESH_WORKER,
   GET_SEED_WALLET,
   GET_SEED_WALLETS,
   IMPORT_SEED_WALLET,
@@ -80,6 +81,11 @@ export async function deactivateRpcProvider(id: number) {
 
 export async function manualStartWorker(namespace: string) {
   const data = await window.api.sendSync(MANUAL_START_WORKER, namespace);
+  return data;
+}
+
+export async function fullRefreshWorker(namespace: string) {
+  const data = await window.api.sendSync(FULL_REFRESH_WORKER, namespace);
   return data;
 }
 

--- a/renderer/generated/models/ApiIdentityMuteState.ts
+++ b/renderer/generated/models/ApiIdentityMuteState.ts
@@ -11,6 +11,8 @@
  * Do not edit the class manually.
  */
 
+import { HttpFile } from '../http/http';
+
 export class ApiIdentityMuteState {
     'muted': boolean;
 

--- a/renderer/helpers/notification.helpers.ts
+++ b/renderer/helpers/notification.helpers.ts
@@ -15,31 +15,79 @@ interface NotificationData {
   title: string;
   body: string;
   redirectPath: string;
+  iconUrl?: string | null;
 }
 
 type FindNativeEmoji = (
   emojiId: string
 ) => { skins: { native: string }[] } | null;
 
+type FindCustomEmoji = (
+  emojiId: string
+) => { skins: { src: string }[] } | null;
+
+interface EmojiResolvers {
+  findNativeEmoji: FindNativeEmoji;
+  findCustomEmoji?: FindCustomEmoji;
+}
+
+interface ReactionPresentation {
+  text: string;
+  iconUrl?: string | null;
+}
+
+const nativeEmojiPattern =
+  /[\p{Emoji_Presentation}\p{Extended_Pictographic}\uFE0F]/u;
+
+const getReactionEmojiIdCandidates = (reaction: string): string[] => {
+  const rawId = reaction.trim().replaceAll(":", "");
+  const underscoreId = rawId.replaceAll("-", "_").replaceAll(" ", "_");
+  const hyphenId = rawId.replaceAll("_", "-").replaceAll(" ", "-");
+
+  return [...new Set([rawId, underscoreId, hyphenId].filter(Boolean))];
+};
+
 export function generateNotificationData(
   notification: ApiNotification,
-  findNativeEmoji: FindNativeEmoji,
+  emojiResolvers: EmojiResolvers,
   connectedProfileHandle?: string | null
 ): NotificationData | null {
   const handle = notification.related_identity?.handle ?? "Someone";
   const cause = notification.cause;
+  const { findNativeEmoji, findCustomEmoji } = emojiResolvers;
 
-  const getEmojiText = (reaction: string): string => {
-    const emojiId = reaction.replaceAll(":", "");
-    const nativeEmoji = findNativeEmoji(emojiId);
-    if (nativeEmoji) {
-      return nativeEmoji.skins[0]?.native ?? "";
+  const getReactionPresentation = (
+    reaction: string
+  ): ReactionPresentation => {
+    const trimmedReaction = reaction.trim();
+    if (nativeEmojiPattern.test(trimmedReaction)) {
+      return { text: trimmedReaction };
     }
+
+    for (const emojiId of getReactionEmojiIdCandidates(trimmedReaction)) {
+      const nativeEmoji = findNativeEmoji(emojiId);
+      const native = nativeEmoji?.skins[0]?.native;
+      if (native) {
+        return { text: native };
+      }
+
+      const emojified = emojify(`:${emojiId}:`);
+      if (emojified !== `:${emojiId}:`) {
+        return { text: emojified };
+      }
+
+      const customEmoji = findCustomEmoji?.(emojiId);
+      const customIconUrl = customEmoji?.skins[0]?.src;
+      if (customIconUrl) {
+        return { text: "", iconUrl: customIconUrl };
+      }
+    }
+
     const normalizedReaction = reaction
       .replaceAll(":", "")
       .replaceAll("-", " ")
       .replaceAll("_", " ");
-    return `'${normalizedReaction}'`;
+    return { text: `'${normalizedReaction}'` };
   };
 
   const getDropContent = (dropIndex: number = 0): string | null => {
@@ -161,12 +209,17 @@ export function generateNotificationData(
       if (!reaction) {
         return null;
       }
-      const emojiText = getEmojiText(reaction);
+      const reactionPresentation = getReactionPresentation(reaction);
       const dropContent = getDropContent();
       notificationData = {
-        title: `${handle} reacted ${emojiText}`,
+        title: `${handle} reacted${
+          reactionPresentation.text ? ` ${reactionPresentation.text}` : ""
+        }`,
         body: dropContent ?? "View drop",
         redirectPath: getWavesRedirect(),
+        ...(reactionPresentation.iconUrl !== undefined && {
+          iconUrl: reactionPresentation.iconUrl,
+        }),
       };
       break;
     }
@@ -235,5 +288,8 @@ export function generateNotificationData(
     title,
     body,
     redirectPath: notificationData.redirectPath,
+    ...(notificationData.iconUrl !== undefined && {
+      iconUrl: notificationData.iconUrl,
+    }),
   };
 }

--- a/shared/abis/manifold.ts
+++ b/shared/abis/manifold.ts
@@ -1,0 +1,6 @@
+export const MANIFOLD_LAZY_CLAIM_CONTRACT =
+  "0x26BBEA7803DcAc346D5F5f135b57Cf2c752A02bE";
+
+export const MANIFOLD_LAZY_CLAIM_ABI = [
+  "function getClaimForToken(address creatorContractAddress, uint256 tokenId) view returns (uint256 instanceId, tuple(uint32 total, uint32 totalMax, uint32 walletMax, uint48 startDate, uint48 endDate, uint8 storageProtocol, bytes32 merkleRoot, string location, uint256 tokenId, uint256 cost, address payable paymentReceiver, address erc20, address signingAddress) claim)",
+];

--- a/shared/memes-edition-size-floor.test.ts
+++ b/shared/memes-edition-size-floor.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { GRADIENT_CONTRACT } from "./abis/gradient";
+import { MEMES_CONTRACT } from "./abis/memes";
+import {
+  calculateHodlRate,
+  getCalculationEditionSize,
+  getMemeEditionSizeFloor,
+  getMemeTokenIdsForEditionSizeFloorRefresh,
+  MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS,
+} from "./memes-edition-size-floor";
+
+describe("meme edition size floor helpers", () => {
+  it("caps positive Manifold claim totals at 310", () => {
+    assert.equal(getMemeEditionSizeFloor(500), 310);
+    assert.equal(getMemeEditionSizeFloor(310), 310);
+    assert.equal(getMemeEditionSizeFloor(168), 168);
+    assert.equal(getMemeEditionSizeFloor(500n), 310);
+    assert.equal(getMemeEditionSizeFloor("320"), 310);
+  });
+
+  it("ignores unavailable or invalid claim totals", () => {
+    assert.equal(getMemeEditionSizeFloor(null), null);
+    assert.equal(getMemeEditionSizeFloor(undefined), null);
+    assert.equal(getMemeEditionSizeFloor(0), null);
+    assert.equal(getMemeEditionSizeFloor(-1), null);
+    assert.equal(getMemeEditionSizeFloor(1.5), null);
+    assert.equal(getMemeEditionSizeFloor("not-a-number"), null);
+  });
+
+  it("uses the larger value from actual supply and edition floor", () => {
+    assert.equal(
+      getCalculationEditionSize({
+        actualSupply: 168,
+        editionSizeFloor: 310,
+      }),
+      310,
+    );
+    assert.equal(
+      getCalculationEditionSize({
+        actualSupply: 652,
+        editionSizeFloor: 310,
+      }),
+      652,
+    );
+    assert.equal(
+      getCalculationEditionSize({
+        actualSupply: 101,
+        editionSizeFloor: 0,
+      }),
+      101,
+    );
+  });
+
+  it("clamps hodl rates to a minimum of 1", () => {
+    assert.equal(calculateHodlRate(3939, 310), 3939 / 310);
+    assert.equal(calculateHodlRate(100, 310), 1);
+    assert.equal(calculateHodlRate(100, 0), 1);
+    assert.equal(calculateHodlRate(100, -1), 1);
+  });
+
+  it("refreshes latest Meme and Memes minted inside the 30-day window", () => {
+    const nowMillis = Date.UTC(2026, 0, 31, 0, 0, 0);
+    const boundaryMintSeconds = Math.floor(
+      (nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS) / 1000,
+    );
+    const oldMintSeconds = boundaryMintSeconds - 1;
+    const recentMintSeconds = boundaryMintSeconds + 1;
+
+    assert.deepEqual(
+      getMemeTokenIdsForEditionSizeFloorRefresh(
+        [
+          { contract: MEMES_CONTRACT, id: 1, mint_date: oldMintSeconds },
+          { contract: MEMES_CONTRACT, id: 2, mint_date: boundaryMintSeconds },
+          { contract: MEMES_CONTRACT, id: 3, mint_date: recentMintSeconds },
+          { contract: MEMES_CONTRACT, id: 5, mint_date: oldMintSeconds },
+          { contract: GRADIENT_CONTRACT, id: 999, mint_date: recentMintSeconds },
+        ],
+        nowMillis,
+      ),
+      [2, 3, 5],
+    );
+  });
+
+  it("returns no refresh ids when there are no Memes", () => {
+    assert.deepEqual(
+      getMemeTokenIdsForEditionSizeFloorRefresh([
+        { contract: GRADIENT_CONTRACT, id: 1, mint_date: 1 },
+      ]),
+      [],
+    );
+  });
+});

--- a/shared/memes-edition-size-floor.ts
+++ b/shared/memes-edition-size-floor.ts
@@ -1,0 +1,57 @@
+export const MEMES_EDITION_SIZE_FLOOR_CAP = 310;
+
+export interface CalculationEditionSizeInput {
+  actualSupply: number;
+  editionSizeFloor?: number | null;
+}
+
+function normalizePositiveInteger(value: unknown): number | null {
+  if (typeof value === "bigint") {
+    if (value <= 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      return null;
+    }
+    return Number(value);
+  }
+
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  return null;
+}
+
+export function getMemeEditionSizeFloor(
+  claimMaxEditionSize: unknown,
+): number | null {
+  const claimMax = normalizePositiveInteger(claimMaxEditionSize);
+  return claimMax === null
+    ? null
+    : Math.min(claimMax, MEMES_EDITION_SIZE_FLOOR_CAP);
+}
+
+export function getCalculationEditionSize({
+  actualSupply,
+  editionSizeFloor,
+}: CalculationEditionSizeInput): number {
+  return Math.max(
+    normalizePositiveInteger(actualSupply) ?? 0,
+    normalizePositiveInteger(editionSizeFloor) ?? 0,
+  );
+}
+
+export function calculateHodlRate(
+  maxSupply: number,
+  calculationEditionSize: number,
+): number {
+  const rate = maxSupply / calculationEditionSize;
+  return !Number.isFinite(rate) || rate < 1 ? 1 : rate;
+}

--- a/shared/memes-edition-size-floor.ts
+++ b/shared/memes-edition-size-floor.ts
@@ -1,8 +1,20 @@
+import { MEMES_CONTRACT } from "./abis/memes";
+import { areEqualAddresses } from "./helpers";
+import { Time } from "./time";
+
 export const MEMES_EDITION_SIZE_FLOOR_CAP = 310;
+export const MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS =
+  Time.days(30).toMillis();
 
 export interface CalculationEditionSizeInput {
   actualSupply: number;
   editionSizeFloor?: number | null;
+}
+
+export interface MemeEditionSizeFloorRefreshNft {
+  contract: string;
+  id: number;
+  mint_date?: number | null;
 }
 
 function normalizePositiveInteger(value: unknown): number | null {
@@ -54,4 +66,33 @@ export function calculateHodlRate(
 ): number {
   const rate = maxSupply / calculationEditionSize;
   return !Number.isFinite(rate) || rate < 1 ? 1 : rate;
+}
+
+export function getMemeTokenIdsForEditionSizeFloorRefresh(
+  nfts: MemeEditionSizeFloorRefreshNft[],
+  nowMillis: number = Time.currentMillis(),
+): number[] {
+  const memes = nfts.filter((nft) =>
+    areEqualAddresses(nft.contract, MEMES_CONTRACT),
+  );
+  if (memes.length === 0) {
+    return [];
+  }
+
+  const refreshCutoff =
+    nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS;
+  const latestMemeId = memes.reduce(
+    (latest, nft) => Math.max(latest, nft.id),
+    0,
+  );
+  const tokenIds = new Set<number>([latestMemeId]);
+
+  memes.forEach((nft) => {
+    const mintMillis = Number(nft.mint_date) * 1000;
+    if (Number.isFinite(mintMillis) && mintMillis >= refreshCutoff) {
+      tokenIds.add(nft.id);
+    }
+  });
+
+  return Array.from(tokenIds).sort((a, b) => a - b);
 }

--- a/shared/preload-types.ts
+++ b/shared/preload-types.ts
@@ -15,6 +15,7 @@ export interface ElectronAPI {
   on: (channel: string, callback: Function) => void;
   send: (channel: string, ...args: any[]) => void;
   sendSync: (channel: string, ...args: any[]) => any;
+  invoke: (channel: string, ...args: any[]) => Promise<any>;
   openExternal: (url: string) => void;
   openExternalChrome: (url: string) => void;
   openExternalFirefox: (url: string) => void;


### PR DESCRIPTION
## Summary
- Add `edition_size_floor` as indexed NFT metadata while preserving actual `edition_size` as minted/current supply.
- Fetch Meme edition-size floors from Manifold claim `totalMax`, capped at 310, and preserve stored floors for older Memes.
- Update TDH hodl-rate math and edition-size-based ranking inputs to use `max(actualSupply, edition_size_floor)` without mutating displayed actual supply.

## Validation
- `./bin/6529 run type-check`

CI was not awaited per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Full Refresh” action for NFT workers, letting you refresh indexed NFT data without deleting local NFT records.
  * Improved notification reactions so custom and native emoji display more reliably.
* **Bug Fixes**
  * NFT indexing and ranking now better account for edition size floors, improving refresh accuracy and TDH calculations.
  * Desktop notification icons now resolve more consistently from available image sources.
* **Tests**
  * Added coverage for notification rendering and meme edition-size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->