### PR TITLE
Fix NFT edition size floor backfill

### DIFF
--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -27,18 +27,34 @@ export async function runCoreMigrations(dataSource: DataSource) {
 
 async function hasMigrationRun(
   dataSource: DataSource,
-  migrationName: string
+  migrationName: string,
+  logIfApplied: boolean = true
 ) {
   const existing = await dataSource.getRepository(CoreMigration).findOne({
     where: { migration_name: migrationName },
   });
 
   if (existing) {
-    Logger.info(loggerName, `Migration ${migrationName} already applied.`);
+    if (logIfApplied) {
+      Logger.info(loggerName, `Migration ${migrationName} already applied.`);
+    }
     return true;
   }
 
   return false;
+}
+
+async function recordMigrationIfNeeded(
+  dataSource: DataSource,
+  migrationName: string
+) {
+  if (await hasMigrationRun(dataSource, migrationName, false)) {
+    return;
+  }
+
+  await dataSource.getRepository(CoreMigration).insert({
+    migration_name: migrationName,
+  });
 }
 
 async function runBlurRoyaltiesMigration(dataSource: DataSource) {
@@ -198,12 +214,11 @@ async function refreshNftEditionSizeFloor(
 
 async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   const migrationName = "nftEditionSizeFloorBackfill";
-
-  if (await hasMigrationRun(dataSource, migrationName)) {
-    return;
-  }
-
-  Logger.info(loggerName, `Running migration ${migrationName}...`);
+  const migrationAlreadyRecorded = await hasMigrationRun(
+    dataSource,
+    migrationName,
+    false
+  );
 
   const nftRepository = dataSource.getRepository(NFT);
   const nfts = await nftRepository.find({
@@ -213,7 +228,32 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
     },
   });
 
-  Logger.info(loggerName, `Found ${nfts.length} NFTs to scan`);
+  if (nfts.length === 0) {
+    Logger.info(
+      loggerName,
+      `Migration ${migrationName} found no NFTs to scan; deferring.`
+    );
+    return;
+  }
+
+  const missingFloorCount = await nftRepository
+    .createQueryBuilder("nft")
+    .where(
+      "nft.edition_size_floor IS NULL OR nft.edition_size_floor <= 0"
+    )
+    .getCount();
+
+  if (migrationAlreadyRecorded && missingFloorCount === 0) {
+    Logger.info(loggerName, `Migration ${migrationName} already applied.`);
+    return;
+  }
+
+  Logger.info(
+    loggerName,
+    `Running migration ${migrationName}...`,
+    `Found ${nfts.length} NFTs to scan.`,
+    `Missing floors: ${missingFloorCount}.`
+  );
 
   const provider = new JsonRpcProvider("https://rpc1.6529.io");
   let copiedFloors = 0;
@@ -263,9 +303,7 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   }
 
   if (failedRefreshes === 0) {
-    await dataSource.getRepository(CoreMigration).insert({
-      migration_name: migrationName,
-    });
+    await recordMigrationIfNeeded(dataSource, migrationName);
   }
 
   Logger.info(

--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -111,8 +111,14 @@ async function runBlurRoyaltiesMigration(dataSource: DataSource) {
   Logger.info(loggerName, `Migration ${migrationName} completed.`);
 }
 
-function getPositiveEditionSize(editionSize: number): number {
-  return Number.isInteger(editionSize) && editionSize > 0 ? editionSize : 0;
+function getPositiveEditionSize(
+  editionSize: number | null | undefined
+): number {
+  return typeof editionSize === "number" &&
+    Number.isInteger(editionSize) &&
+    editionSize > 0
+    ? editionSize
+    : 0;
 }
 
 async function updateEditionSizeFloor(
@@ -176,6 +182,18 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   );
 
   const nftRepository = dataSource.getRepository(NFT);
+  const missingFloorCount = await nftRepository
+    .createQueryBuilder("nft")
+    .where(
+      "nft.edition_size_floor IS NULL OR nft.edition_size_floor <= 0"
+    )
+    .getCount();
+
+  if (migrationAlreadyRecorded && missingFloorCount === 0) {
+    Logger.info(loggerName, `Migration ${migrationName} already applied.`);
+    return;
+  }
+
   const nfts = await nftRepository.find({
     order: {
       contract: "ASC",
@@ -188,18 +206,6 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
       loggerName,
       `Migration ${migrationName} found no NFTs to scan; deferring.`
     );
-    return;
-  }
-
-  const missingFloorCount = await nftRepository
-    .createQueryBuilder("nft")
-    .where(
-      "nft.edition_size_floor IS NULL OR nft.edition_size_floor <= 0"
-    )
-    .getCount();
-
-  if (migrationAlreadyRecorded && missingFloorCount === 0) {
-    Logger.info(loggerName, `Migration ${migrationName} already applied.`);
     return;
   }
 
@@ -216,6 +222,7 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   const latestMemeId = nfts
     .filter((nft) => areEqualAddresses(nft.contract, MEMES_CONTRACT))
     .reduce((latest, nft) => Math.max(latest, nft.id), 0);
+  const hasLatestMeme = latestMemeId > 0;
   let copiedFloors = 0;
   let latestMemeRefreshes = 0;
   let nonMemeFloors = 0;
@@ -232,7 +239,7 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
       continue;
     }
 
-    if (nft.id !== latestMemeId) {
+    if (!hasLatestMeme || nft.id !== latestMemeId) {
       const existingFloor = getPositiveEditionSize(nft.edition_size_floor);
       const editionSizeFloor = repairBrokenPositiveFloors
         ? editionSize

--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -7,18 +7,11 @@ import { NEXTGEN_CONTRACT } from "../../shared/abis/nextgen";
 import { findTransactionValues } from "../scheduled-tasks/workers/transactions-worker/transaction-values";
 import { ethers, JsonRpcProvider } from "ethers";
 import { NFT } from "./entities/INFT";
-import {
-  Contract,
-  ContractType,
-  getEditionSizes,
-  getTokenUri,
-  retrieveNftFromURI,
-} from "../scheduled-tasks/workers/nft-worker/nft-worker";
+import { getEditionSizes } from "../scheduled-tasks/workers/nft-worker/nft-worker";
 import { MEMES_ABI, MEMES_CONTRACT } from "../../shared/abis/memes";
 import { areEqualAddresses } from "../../shared/helpers";
 
 const loggerName = "[DB MIGRATIONS]";
-const EDITION_SIZE_FLOOR_FULL_REFRESH_THRESHOLD = 300;
 
 export async function runCoreMigrations(dataSource: DataSource) {
   await runBlurRoyaltiesMigration(dataSource);
@@ -118,13 +111,6 @@ async function runBlurRoyaltiesMigration(dataSource: DataSource) {
   Logger.info(loggerName, `Migration ${migrationName} completed.`);
 }
 
-const MEMES_CONTRACT_OBJECT: Contract = {
-  name: "The Memes",
-  address: MEMES_CONTRACT,
-  abi: MEMES_ABI,
-  type: ContractType.ERC1155,
-};
-
 function getPositiveEditionSize(editionSize: number): number {
   return Number.isInteger(editionSize) && editionSize > 0 ? editionSize : 0;
 }
@@ -151,50 +137,19 @@ async function updateEditionSizeFloor(
   return true;
 }
 
-async function refreshNftEditionSizeFloor(
+async function updateNftEditionFields(
   dataSource: DataSource,
-  provider: ethers.JsonRpcProvider,
   nft: NFT,
-  contract: Contract
+  editionSize: number,
+  editionSizeFloor: number,
+  burns: number
 ) {
-  const ethersContract = new ethers.Contract(
-    contract.address,
-    contract.abi,
-    provider
-  );
-  const editionSizes = await getEditionSizes(
-    dataSource,
-    contract.address,
-    ethersContract,
-    nft.id,
-    {
-      provider,
-      refreshEditionSizeFloor: true,
-      backfillMissingEditionSizeFloor: true,
-    }
-  );
-
-  const tokenUri = await getTokenUri(contract.type, ethersContract, nft.id);
-  const metadataUri = tokenUri || nft.uri;
-
-  if (metadataUri) {
-    try {
-      const updatedNft = await retrieveNftFromURI(
-        dataSource,
-        contract.address,
-        nft.id,
-        metadataUri,
-        editionSizes
-      );
-      await dataSource.getRepository(NFT).save(updatedNft);
-      return "full";
-    } catch (error) {
-      Logger.warn(
-        loggerName,
-        `Failed to refresh metadata for ${contract.name} #${nft.id}; saving edition-size fields only.`,
-        error
-      );
-    }
+  if (
+    nft.edition_size === editionSize &&
+    nft.edition_size_floor === editionSizeFloor &&
+    nft.burns === burns
+  ) {
+    return false;
   }
 
   await dataSource.getRepository(NFT).update(
@@ -203,17 +158,17 @@ async function refreshNftEditionSizeFloor(
       id: nft.id,
     },
     {
-      edition_size: editionSizes.editionSize,
-      edition_size_floor: editionSizes.editionSizeFloor,
-      burns: editionSizes.burnt,
+      edition_size: editionSize,
+      edition_size_floor: editionSizeFloor,
+      burns,
     }
   );
 
-  return "fields";
+  return true;
 }
 
 async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
-  const migrationName = "nftEditionSizeFloorBackfill";
+  const migrationName = "nftEditionSizeFloorLatestMemeRepair";
   const migrationAlreadyRecorded = await hasMigrationRun(
     dataSource,
     migrationName,
@@ -256,9 +211,13 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   );
 
   const provider = new JsonRpcProvider("https://rpc1.6529.io");
+  const memesContract = new ethers.Contract(MEMES_CONTRACT, MEMES_ABI, provider);
+  const repairBrokenPositiveFloors = !migrationAlreadyRecorded;
+  const latestMemeId = nfts
+    .filter((nft) => areEqualAddresses(nft.contract, MEMES_CONTRACT))
+    .reduce((latest, nft) => Math.max(latest, nft.id), 0);
   let copiedFloors = 0;
-  let fullRefreshes = 0;
-  let fieldRefreshes = 0;
+  let latestMemeRefreshes = 0;
   let nonMemeFloors = 0;
   let failedRefreshes = 0;
 
@@ -273,24 +232,39 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
       continue;
     }
 
-    if (editionSize >= EDITION_SIZE_FLOOR_FULL_REFRESH_THRESHOLD) {
-      if (await updateEditionSizeFloor(dataSource, nft, editionSize)) {
+    if (nft.id !== latestMemeId) {
+      const existingFloor = getPositiveEditionSize(nft.edition_size_floor);
+      const editionSizeFloor = repairBrokenPositiveFloors
+        ? editionSize
+        : existingFloor || editionSize;
+      if (await updateEditionSizeFloor(dataSource, nft, editionSizeFloor)) {
         copiedFloors++;
       }
       continue;
     }
 
     try {
-      const refreshResult = await refreshNftEditionSizeFloor(
+      const editionSizes = await getEditionSizes(
         dataSource,
-        provider,
-        nft,
-        MEMES_CONTRACT_OBJECT
+        MEMES_CONTRACT,
+        memesContract,
+        nft.id,
+        {
+          provider,
+          refreshEditionSizeFloor: true,
+          preserveExistingEditionSizeFloor: !repairBrokenPositiveFloors,
+        }
       );
-      if (refreshResult === "full") {
-        fullRefreshes++;
-      } else {
-        fieldRefreshes++;
+      if (
+        await updateNftEditionFields(
+          dataSource,
+          nft,
+          editionSizes.editionSize,
+          editionSizes.editionSizeFloor,
+          editionSizes.burnt
+        )
+      ) {
+        latestMemeRefreshes++;
       }
     } catch (error) {
       failedRefreshes++;
@@ -312,8 +286,7 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
       ? `Migration ${migrationName} completed.`
       : `Migration ${migrationName} partially completed and will retry.`,
     `Copied floors: ${copiedFloors}.`,
-    `Full refreshes: ${fullRefreshes}.`,
-    `Field refreshes: ${fieldRefreshes}.`,
+    `Latest Meme refreshes: ${latestMemeRefreshes}.`,
     `Non-Meme rows normalized: ${nonMemeFloors}.`,
     `Failed refreshes: ${failedRefreshes}.`
   );

--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -121,10 +121,17 @@ function getPositiveEditionSize(
     : 0;
 }
 
+function getEditionSizeFloorFromSupply(
+  editionSize: number | null | undefined
+): number | null {
+  const positiveEditionSize = getPositiveEditionSize(editionSize);
+  return positiveEditionSize > 0 ? positiveEditionSize : null;
+}
+
 async function updateEditionSizeFloor(
   dataSource: DataSource,
   nft: NFT,
-  editionSizeFloor: number
+  editionSizeFloor: number | null
 ) {
   if (nft.edition_size_floor === editionSizeFloor) {
     return false;
@@ -185,7 +192,7 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   const missingFloorCount = await nftRepository
     .createQueryBuilder("nft")
     .where(
-      "nft.edition_size_floor IS NULL OR nft.edition_size_floor <= 0"
+      "(nft.edition_size_floor IS NULL OR nft.edition_size_floor <= 0) AND nft.edition_size > 0"
     )
     .getCount();
 
@@ -229,10 +236,9 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
   let failedRefreshes = 0;
 
   for (const nft of nfts) {
-    const editionSize = getPositiveEditionSize(nft.edition_size);
-
     if (!areEqualAddresses(nft.contract, MEMES_CONTRACT)) {
-      if (await updateEditionSizeFloor(dataSource, nft, editionSize)) {
+      const editionSizeFloor = getEditionSizeFloorFromSupply(nft.edition_size);
+      if (await updateEditionSizeFloor(dataSource, nft, editionSizeFloor)) {
         copiedFloors++;
       }
       nonMemeFloors++;
@@ -242,8 +248,8 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
     if (!hasLatestMeme || nft.id !== latestMemeId) {
       const existingFloor = getPositiveEditionSize(nft.edition_size_floor);
       const editionSizeFloor = repairBrokenPositiveFloors
-        ? editionSize
-        : existingFloor || editionSize;
+        ? getEditionSizeFloorFromSupply(nft.edition_size)
+        : existingFloor || getEditionSizeFloorFromSupply(nft.edition_size);
       if (await updateEditionSizeFloor(dataSource, nft, editionSizeFloor)) {
         copiedFloors++;
       }

--- a/electron-src/db/db.migrations.ts
+++ b/electron-src/db/db.migrations.ts
@@ -154,7 +154,7 @@ async function updateNftEditionFields(
   dataSource: DataSource,
   nft: NFT,
   editionSize: number,
-  editionSizeFloor: number,
+  editionSizeFloor: number | null,
   burns: number
 ) {
   if (
@@ -246,10 +246,12 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
     }
 
     if (!hasLatestMeme || nft.id !== latestMemeId) {
-      const existingFloor = getPositiveEditionSize(nft.edition_size_floor);
+      const existingFloor = getEditionSizeFloorFromSupply(
+        nft.edition_size_floor
+      );
       const editionSizeFloor = repairBrokenPositiveFloors
         ? getEditionSizeFloorFromSupply(nft.edition_size)
-        : existingFloor || getEditionSizeFloorFromSupply(nft.edition_size);
+        : existingFloor ?? getEditionSizeFloorFromSupply(nft.edition_size);
       if (await updateEditionSizeFloor(dataSource, nft, editionSizeFloor)) {
         copiedFloors++;
       }
@@ -268,12 +270,15 @@ async function runNftEditionSizeFloorMigration(dataSource: DataSource) {
           preserveExistingEditionSizeFloor: !repairBrokenPositiveFloors,
         }
       );
+      const editionSizeFloor =
+        getEditionSizeFloorFromSupply(editionSizes.editionSizeFloor) ??
+        getEditionSizeFloorFromSupply(editionSizes.editionSize);
       if (
         await updateNftEditionFields(
           dataSource,
           nft,
           editionSizes.editionSize,
-          editionSizes.editionSizeFloor,
+          editionSizeFloor,
           editionSizes.burnt
         )
       ) {

--- a/electron-src/db/entities/INFT.ts
+++ b/electron-src/db/entities/INFT.ts
@@ -51,8 +51,8 @@ export class NFT {
   @Column({ type: "int", default: 0 })
   edition_size!: number;
 
-  @Column({ type: "int", default: 0 })
-  edition_size_floor!: number;
+  @Column({ type: "int", nullable: true })
+  edition_size_floor!: number | null;
 
   @Column({ type: "int", default: 0 })
   burns!: number;

--- a/electron-src/scheduled-tasks/workers/nft-edition-size-floor-persistence.ts
+++ b/electron-src/scheduled-tasks/workers/nft-edition-size-floor-persistence.ts
@@ -1,4 +1,4 @@
-import { DataSource, In } from "typeorm";
+import { DataSource, EntityManager } from "typeorm";
 import { NFT } from "../../db/entities/INFT";
 
 function getPositiveInteger(value: number | null | undefined): number | null {
@@ -15,24 +15,24 @@ function getNftKey(nft: Pick<NFT, "contract" | "id">) {
 }
 
 export async function preserveEditionSizeFloors(
-  db: DataSource,
+  db: DataSource | EntityManager,
   nfts: NFT[],
 ) {
   if (nfts.length === 0) {
     return nfts;
   }
 
-  const distinctContracts = [...new Set(nfts.map((nft) => nft.contract))];
-  const existingNfts = await db.getRepository(NFT).find({
-    select: {
-      contract: true,
-      id: true,
-      edition_size_floor: true,
-    },
-    where: {
-      contract: In(distinctContracts),
-    },
-  });
+  const distinctContracts = [
+    ...new Set(nfts.map((nft) => nft.contract.toLowerCase())),
+  ];
+  const existingNfts = await db
+    .getRepository(NFT)
+    .createQueryBuilder("nft")
+    .select(["nft.contract", "nft.id", "nft.edition_size_floor"])
+    .where("LOWER(nft.contract) IN (:...contracts)", {
+      contracts: distinctContracts,
+    })
+    .getMany();
   const existingFloors = new Map(
     existingNfts
       .map((nft) => [
@@ -47,12 +47,14 @@ export async function preserveEditionSizeFloors(
       return nft;
     }
 
+    const editionSizeFloor =
+      existingFloors.get(getNftKey(nft)) ??
+      getPositiveInteger(nft.edition_size) ??
+      null;
+
     return {
       ...nft,
-      edition_size_floor:
-        existingFloors.get(getNftKey(nft)) ??
-        getPositiveInteger(nft.edition_size) ??
-        0,
+      edition_size_floor: editionSizeFloor,
     };
   });
 }

--- a/electron-src/scheduled-tasks/workers/nft-edition-size-floor-persistence.ts
+++ b/electron-src/scheduled-tasks/workers/nft-edition-size-floor-persistence.ts
@@ -1,0 +1,58 @@
+import { DataSource, In } from "typeorm";
+import { NFT } from "../../db/entities/INFT";
+
+function getPositiveInteger(value: number | null | undefined): number | null {
+  return value !== null &&
+    value !== undefined &&
+    Number.isInteger(value) &&
+    value > 0
+    ? value
+    : null;
+}
+
+function getNftKey(nft: Pick<NFT, "contract" | "id">) {
+  return `${nft.contract.toLowerCase()}-${nft.id}`;
+}
+
+export async function preserveEditionSizeFloors(
+  db: DataSource,
+  nfts: NFT[],
+) {
+  if (nfts.length === 0) {
+    return nfts;
+  }
+
+  const distinctContracts = [...new Set(nfts.map((nft) => nft.contract))];
+  const existingNfts = await db.getRepository(NFT).find({
+    select: {
+      contract: true,
+      id: true,
+      edition_size_floor: true,
+    },
+    where: {
+      contract: In(distinctContracts),
+    },
+  });
+  const existingFloors = new Map(
+    existingNfts
+      .map((nft) => [
+        getNftKey(nft),
+        getPositiveInteger(nft.edition_size_floor),
+      ])
+      .filter((entry): entry is [string, number] => entry[1] !== null),
+  );
+
+  return nfts.map((nft) => {
+    if (getPositiveInteger(nft.edition_size_floor) !== null) {
+      return nft;
+    }
+
+    return {
+      ...nft,
+      edition_size_floor:
+        existingFloors.get(getNftKey(nft)) ??
+        getPositiveInteger(nft.edition_size) ??
+        0,
+    };
+  });
+}

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
@@ -256,6 +256,64 @@ class NFTWorker extends CoreWorker {
         break;
       }
     }
+
+    if (areEqualAddresses(contract.address, MEMES_CONTRACT)) {
+      await this.refreshLatestMemeEditionSizeFloor(ethersContract, printStatus);
+    }
+  }
+
+  private async refreshLatestMemeEditionSizeFloor(
+    ethersContract: ethers.Contract,
+    printStatus: (...args: any[]) => void,
+  ) {
+    const latestMeme = await this.getDb()
+      .getRepository(NFT)
+      .findOne({
+        where: {
+          contract: MEMES_CONTRACT,
+        },
+        order: {
+          id: "DESC",
+        },
+      });
+
+    if (!latestMeme) {
+      return;
+    }
+
+    printStatus(`Refreshing latest Meme #${latestMeme.id} edition size floor`);
+    const editionSizes = await getEditionSizes(
+      this.getDb(),
+      MEMES_CONTRACT,
+      ethersContract,
+      latestMeme.id,
+      {
+        provider: this.getProvider(),
+        refreshEditionSizeFloor: true,
+      },
+    );
+
+    if (
+      editionSizes.editionSize === latestMeme.edition_size &&
+      editionSizes.editionSizeFloor === latestMeme.edition_size_floor &&
+      editionSizes.burnt === latestMeme.burns
+    ) {
+      return;
+    }
+
+    await this.getDb()
+      .getRepository(NFT)
+      .update(
+        {
+          contract: latestMeme.contract,
+          id: latestMeme.id,
+        },
+        {
+          edition_size: editionSizes.editionSize,
+          edition_size_floor: editionSizes.editionSizeFloor,
+          burns: editionSizes.burnt,
+        },
+      );
   }
 
   async processNextgen() {
@@ -395,7 +453,6 @@ class NFTWorker extends CoreWorker {
         {
           provider: this.getProvider(),
           refreshEditionSizeFloor: refreshEditionSizeFloorTokenIds.has(nft.id),
-          backfillMissingEditionSizeFloor: true,
         },
       );
       const mintDate = await getMintDate(

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-discovery.ts
@@ -298,6 +298,9 @@ class NFTWorker extends CoreWorker {
       editionSizes.editionSizeFloor === latestMeme.edition_size_floor &&
       editionSizes.burnt === latestMeme.burns
     ) {
+      printStatus(
+        `Latest Meme #${latestMeme.id} edition size already current: actual ${latestMeme.edition_size}, floor ${latestMeme.edition_size_floor}, burns ${latestMeme.burns}`,
+      );
       return;
     }
 
@@ -314,6 +317,9 @@ class NFTWorker extends CoreWorker {
           burns: editionSizes.burnt,
         },
       );
+    printStatus(
+      `Latest Meme #${latestMeme.id} edition size updated: actual ${latestMeme.edition_size} -> ${editionSizes.editionSize}, floor ${latestMeme.edition_size_floor} -> ${editionSizes.editionSizeFloor}, burns ${latestMeme.burns} -> ${editionSizes.burnt}`,
+    );
   }
 
   async processNextgen() {

--- a/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nft-worker.ts
@@ -44,7 +44,7 @@ export interface EditionSizes {
 interface GetEditionSizesOptions {
   provider?: ethers.Provider;
   refreshEditionSizeFloor?: boolean;
-  backfillMissingEditionSizeFloor?: boolean;
+  preserveExistingEditionSizeFloor?: boolean;
 }
 
 const GRADIENT_SUPPLY = 101;
@@ -280,12 +280,10 @@ async function resolveEditionSizeFloor(
     contractAddress,
     tokenId,
   );
+  const preserveExistingFloor =
+    options.preserveExistingEditionSizeFloor ?? true;
 
-  if (
-    options.provider &&
-    (options.refreshEditionSizeFloor ||
-      (options.backfillMissingEditionSizeFloor && existingFloor === null))
-  ) {
+  if (options.provider && options.refreshEditionSizeFloor) {
     const onChainFloor = await fetchMemeEditionSizeFloorFromClaim(
       options.provider,
       tokenId,
@@ -295,7 +293,7 @@ async function resolveEditionSizeFloor(
     }
   }
 
-  return existingFloor ?? actualSupply;
+  return preserveExistingFloor ? existingFloor ?? actualSupply : actualSupply;
 }
 
 async function getExistingEditionSizeFloor(

--- a/electron-src/scheduled-tasks/workers/nft-worker/nfts-worker.db.ts
+++ b/electron-src/scheduled-tasks/workers/nft-worker/nfts-worker.db.ts
@@ -1,6 +1,7 @@
 import { DataSource } from "typeorm";
 import { NFT } from "../../../db/entities/INFT";
 import { batchUpsert } from "../../worker-helpers";
+import { preserveEditionSizeFloors } from "../nft-edition-size-floor-persistence";
 
 export const persistNfts = async (
   db: DataSource,
@@ -13,7 +14,8 @@ export const persistNfts = async (
   while (attempt < maxRetries) {
     try {
       const nftsRepository = db.getRepository(NFT);
-      await batchUpsert(nftsRepository, nfts, ["id", "contract"]);
+      const nftsWithFloors = await preserveEditionSizeFloors(db, nfts);
+      await batchUpsert(nftsRepository, nftsWithFloors, ["id", "contract"]);
       return;
     } catch (error) {
       if (

--- a/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.db.ts
+++ b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.db.ts
@@ -22,6 +22,7 @@ import { NFT } from "../../../db/entities/INFT";
 import { batchSave } from "../../worker-helpers";
 import { getMerkleRoot } from "./tdh-worker.merkle";
 import { Consolidation } from "../../../db/entities/IDelegation";
+import { preserveEditionSizeFloors } from "../nft-edition-size-floor-persistence";
 
 export async function fetchAllConsolidationAddresses(db: DataSource) {
   const sql = `SELECT wallet FROM (
@@ -398,11 +399,12 @@ export async function persistConsolidatedTDH(
 
 export async function persistNFTs(db: DataSource, nfts: NFT[]) {
   const distinctContracts = [...new Set(nfts.map((nft) => nft.contract))];
+  const nftsWithFloors = await preserveEditionSizeFloors(db, nfts);
   await db.transaction(async (manager) => {
     const nftRepo = manager.getRepository(NFT);
     await nftRepo.delete({
       contract: In(distinctContracts),
     });
-    await batchSave(nftRepo, nfts);
+    await batchSave(nftRepo, nftsWithFloors);
   });
 }

--- a/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.db.ts
+++ b/electron-src/scheduled-tasks/workers/tdh-worker/tdh-worker.db.ts
@@ -398,13 +398,19 @@ export async function persistConsolidatedTDH(
 }
 
 export async function persistNFTs(db: DataSource, nfts: NFT[]) {
-  const distinctContracts = [...new Set(nfts.map((nft) => nft.contract))];
-  const nftsWithFloors = await preserveEditionSizeFloors(db, nfts);
+  const distinctContracts = [
+    ...new Set(nfts.map((nft) => nft.contract.toLowerCase())),
+  ];
   await db.transaction(async (manager) => {
     const nftRepo = manager.getRepository(NFT);
-    await nftRepo.delete({
-      contract: In(distinctContracts),
-    });
+    const nftsWithFloors = await preserveEditionSizeFloors(manager, nfts);
+    await nftRepo
+      .createQueryBuilder()
+      .delete()
+      .where("LOWER(contract) IN (:...contracts)", {
+        contracts: distinctContracts,
+      })
+      .execute();
     await batchSave(nftRepo, nftsWithFloors);
   });
 }

--- a/shared/memes-edition-size-floor.test.ts
+++ b/shared/memes-edition-size-floor.test.ts
@@ -7,7 +7,6 @@ import {
   getCalculationEditionSize,
   getMemeEditionSizeFloor,
   getMemeTokenIdsForEditionSizeFloorRefresh,
-  MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS,
 } from "./memes-edition-size-floor";
 
 describe("meme edition size floor helpers", () => {
@@ -59,26 +58,15 @@ describe("meme edition size floor helpers", () => {
     assert.equal(calculateHodlRate(100, -1), 1);
   });
 
-  it("refreshes latest Meme and Memes minted inside the 30-day window", () => {
-    const nowMillis = Date.UTC(2026, 0, 31, 0, 0, 0);
-    const boundaryMintSeconds = Math.floor(
-      (nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS) / 1000,
-    );
-    const oldMintSeconds = boundaryMintSeconds - 1;
-    const recentMintSeconds = boundaryMintSeconds + 1;
-
+  it("refreshes only the latest Meme", () => {
     assert.deepEqual(
-      getMemeTokenIdsForEditionSizeFloorRefresh(
-        [
-          { contract: MEMES_CONTRACT, id: 1, mint_date: oldMintSeconds },
-          { contract: MEMES_CONTRACT, id: 2, mint_date: boundaryMintSeconds },
-          { contract: MEMES_CONTRACT, id: 3, mint_date: recentMintSeconds },
-          { contract: MEMES_CONTRACT, id: 5, mint_date: oldMintSeconds },
-          { contract: GRADIENT_CONTRACT, id: 999, mint_date: recentMintSeconds },
-        ],
-        nowMillis,
-      ),
-      [2, 3, 5],
+      getMemeTokenIdsForEditionSizeFloorRefresh([
+        { contract: MEMES_CONTRACT, id: 1 },
+        { contract: MEMES_CONTRACT, id: 2 },
+        { contract: MEMES_CONTRACT, id: 5 },
+        { contract: GRADIENT_CONTRACT, id: 999 },
+      ]),
+      [5],
     );
   });
 

--- a/shared/memes-edition-size-floor.test.ts
+++ b/shared/memes-edition-size-floor.test.ts
@@ -73,7 +73,7 @@ describe("meme edition size floor helpers", () => {
   it("returns no refresh ids when there are no Memes", () => {
     assert.deepEqual(
       getMemeTokenIdsForEditionSizeFloorRefresh([
-        { contract: GRADIENT_CONTRACT, id: 1, mint_date: 1 },
+        { contract: GRADIENT_CONTRACT, id: 1 },
       ]),
       [],
     );

--- a/shared/memes-edition-size-floor.ts
+++ b/shared/memes-edition-size-floor.ts
@@ -1,10 +1,7 @@
 import { MEMES_CONTRACT } from "./abis/memes";
 import { areEqualAddresses } from "./helpers";
-import { Time } from "./time";
 
 export const MEMES_EDITION_SIZE_FLOOR_CAP = 310;
-export const MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS =
-  Time.days(30).toMillis();
 
 export interface CalculationEditionSizeInput {
   actualSupply: number;
@@ -14,7 +11,6 @@ export interface CalculationEditionSizeInput {
 export interface MemeEditionSizeFloorRefreshNft {
   contract: string;
   id: number;
-  mint_date?: number | null;
 }
 
 function normalizePositiveInteger(value: unknown): number | null {
@@ -70,7 +66,6 @@ export function calculateHodlRate(
 
 export function getMemeTokenIdsForEditionSizeFloorRefresh(
   nfts: MemeEditionSizeFloorRefreshNft[],
-  nowMillis: number = Time.currentMillis(),
 ): number[] {
   const memes = nfts.filter((nft) =>
     areEqualAddresses(nft.contract, MEMES_CONTRACT),
@@ -79,20 +74,9 @@ export function getMemeTokenIdsForEditionSizeFloorRefresh(
     return [];
   }
 
-  const refreshCutoff =
-    nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS;
   const latestMemeId = memes.reduce(
     (latest, nft) => Math.max(latest, nft.id),
     0,
   );
-  const tokenIds = new Set<number>([latestMemeId]);
-
-  memes.forEach((nft) => {
-    const mintMillis = Number(nft.mint_date) * 1000;
-    if (Number.isFinite(mintMillis) && mintMillis >= refreshCutoff) {
-      tokenIds.add(nft.id);
-    }
-  });
-
-  return Array.from(tokenIds).sort((a, b) => a - b);
+  return [latestMemeId];
 }


### PR DESCRIPTION
## Summary
- rerun the NFT edition-size floor backfill when rows still have missing floors, even if the original migration marker exists
- defer marking the migration complete when no NFT rows exist yet
- preserve existing positive edition_size_floor values when NFT and TDH workers rewrite NFT rows

## Validation
- ./bin/6529 run type-check

## Notes
- Current broken local DB state has the migration marker present but all NFT rows still at edition_size_floor = 0; this fix makes startup repair that state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFT persistence so edition floor values are preserved or backfilled when missing, helping prevent invalid or empty floor data from being saved.
  * Updated migration handling to avoid duplicate recording and unnecessary scans, making database updates more reliable and efficient.
  * Added better handling for NFTs with missing or non-positive edition floor values during background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->