### PR TITLE
Add CI pipeline wave alerts

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref_name }}
+          persist-credentials: false
 
       - name: Set up Node for notifications
         uses: actions/setup-node@v4

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -75,6 +75,12 @@ jobs:
     # Run this notifier only for single-platform flows; Build All/Publish are handled by the publish job
     if: ${{ always() && (github.event.inputs.flow == 'MacOS' || github.event.inputs.flow == 'Windows' || github.event.inputs.flow == 'Linux' || github.event.inputs.flow == 'Sign Windows') }}
     steps:
+      - name: Check out notification scripts
+        uses: actions/checkout@v3
+        continue-on-error: true
+        with:
+          ref: ${{ github.ref_name }}
+
       - name: Determine required build status
         run: |
           SHOULD_FAIL=false
@@ -107,6 +113,21 @@ jobs:
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
+      - name: Notify CI wave about build failure (single-platform flow)
+        if: env.SHOULD_FAIL == 'true'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify build success (single-platform flow)
         if: env.SHOULD_FAIL != 'true'
         uses: sarisia/actions-status-discord@v1
@@ -118,6 +139,21 @@ jobs:
           title: "6529 Desktop - Build Success ✅"
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00ff00
+
+      - name: Notify CI wave about build success (single-platform flow)
+        if: env.SHOULD_FAIL != 'true'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: "6529 Desktop - Build Success ✅"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
 
   publish:
     if: ${{ github.event.inputs.flow == 'Build All' || github.event.inputs.flow == 'Publish' }}
@@ -143,6 +179,12 @@ jobs:
 
           echo "SHOULD_FAIL=$SHOULD_FAIL" >> $GITHUB_ENV
 
+      - name: Check out notification scripts
+        uses: actions/checkout@v3
+        continue-on-error: true
+        with:
+          ref: ${{ github.ref_name }}
+
       - name: Notify required build failure
         if: env.SHOULD_FAIL == 'true'
         uses: sarisia/actions-status-discord@v1
@@ -155,6 +197,21 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
+
+      - name: Notify CI wave about required build failure
+        if: env.SHOULD_FAIL == 'true'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
 
       - name: Check out
         if: env.SHOULD_FAIL != 'true'
@@ -212,6 +269,21 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00bfff
 
+      - name: Notify CI wave about S3 links published
+        if: success() && env.SHOULD_FAIL != 'true'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: "6529 Desktop - S3 links published ✅"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Publish Arweave Links
         if: env.SHOULD_FAIL != 'true' && github.event.inputs.env == 'Production'
         env:
@@ -235,6 +307,19 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00ff00
 
+      - name: Notify CI wave about final production build success
+        if: success() && env.SHOULD_FAIL != 'true' && github.event.inputs.env == 'Production'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: "6529 Desktop - Build complete 🚀"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify Publish Failure
         if: failure()
         uses: sarisia/actions-status-discord@v1
@@ -247,6 +332,21 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
+
+      - name: Notify CI wave about publish failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - Publish job failed ❌"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
 
       - name: Summary
         if: always()
@@ -317,6 +417,21 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00bfff
 
+      - name: Notify CI wave about CloudFront invalidation success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidated ✅"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify Failure
         if: failure()
         uses: sarisia/actions-status-discord@v1
@@ -329,3 +444,18 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
+
+      - name: Notify CI wave about CloudFront invalidation failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidation failed ❌"
+          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop
+        run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -121,10 +121,8 @@ jobs:
         if: env.SHOULD_FAIL == 'true'
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
@@ -148,10 +146,8 @@ jobs:
         if: env.SHOULD_FAIL != 'true'
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - Build Success ✅"
@@ -217,10 +213,8 @@ jobs:
         if: env.SHOULD_FAIL == 'true'
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
@@ -268,10 +262,8 @@ jobs:
         if: success() && env.SHOULD_FAIL != 'true'
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - S3 links published ✅"
@@ -306,8 +298,8 @@ jobs:
         if: success() && env.SHOULD_FAIL != 'true' && github.event.inputs.env == 'Production'
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - Build complete 🚀"
@@ -332,10 +324,8 @@ jobs:
         if: failure()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Publish job failed ❌"
@@ -416,10 +406,8 @@ jobs:
         if: success()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidated ✅"
@@ -444,10 +432,8 @@ jobs:
         if: failure()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidation failed ❌"

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -75,12 +75,6 @@ jobs:
     # Run this notifier only for single-platform flows; Build All/Publish are handled by the publish job
     if: ${{ always() && (github.event.inputs.flow == 'MacOS' || github.event.inputs.flow == 'Windows' || github.event.inputs.flow == 'Linux' || github.event.inputs.flow == 'Sign Windows') }}
     steps:
-      - name: Check out notification scripts
-        uses: actions/checkout@v3
-        continue-on-error: true
-        with:
-          ref: ${{ github.ref_name }}
-
       - name: Determine required build status
         run: |
           SHOULD_FAIL=false
@@ -113,6 +107,18 @@ jobs:
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
+      - name: Check out notification scripts for build failure
+        if: env.SHOULD_FAIL == 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node for build failure notification
+        if: env.SHOULD_FAIL == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Notify CI wave about build failure (single-platform flow)
         if: env.SHOULD_FAIL == 'true'
         continue-on-error: true
@@ -139,6 +145,18 @@ jobs:
           title: "6529 Desktop - Build Success ✅"
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00ff00
+
+      - name: Check out notification scripts for build success
+        if: env.SHOULD_FAIL != 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node for build success notification
+        if: env.SHOULD_FAIL != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Notify CI wave about build success (single-platform flow)
         if: env.SHOULD_FAIL != 'true'
@@ -179,12 +197,6 @@ jobs:
 
           echo "SHOULD_FAIL=$SHOULD_FAIL" >> $GITHUB_ENV
 
-      - name: Check out notification scripts
-        uses: actions/checkout@v3
-        continue-on-error: true
-        with:
-          ref: ${{ github.ref_name }}
-
       - name: Notify required build failure
         if: env.SHOULD_FAIL == 'true'
         uses: sarisia/actions-status-discord@v1
@@ -197,6 +209,18 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
+
+      - name: Check out notification scripts for required build failure
+        if: env.SHOULD_FAIL == 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node for required build failure notification
+        if: env.SHOULD_FAIL == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
       - name: Notify CI wave about required build failure
         if: env.SHOULD_FAIL == 'true'

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
@@ -148,6 +149,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - Build Success ✅"
@@ -215,6 +217,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
@@ -264,6 +267,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - S3 links published ✅"
@@ -300,6 +304,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - Build complete 🚀"
@@ -326,6 +331,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Publish job failed ❌"
@@ -408,6 +414,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidated ✅"
@@ -434,6 +441,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidation failed ❌"

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -75,6 +75,16 @@ jobs:
     # Run this notifier only for single-platform flows; Build All/Publish are handled by the publish job
     if: ${{ always() && (github.event.inputs.flow == 'MacOS' || github.event.inputs.flow == 'Windows' || github.event.inputs.flow == 'Linux' || github.event.inputs.flow == 'Sign Windows') }}
     steps:
+      - name: Check out notification scripts
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up Node for notifications
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Determine required build status
         run: |
           SHOULD_FAIL=false
@@ -107,18 +117,6 @@ jobs:
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
-      - name: Check out notification scripts for build failure
-        if: env.SHOULD_FAIL == 'true'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up Node for build failure notification
-        if: env.SHOULD_FAIL == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Notify CI wave about build failure (single-platform flow)
         if: env.SHOULD_FAIL == 'true'
         continue-on-error: true
@@ -145,18 +143,6 @@ jobs:
           title: "6529 Desktop - Build Success ✅"
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00ff00
-
-      - name: Check out notification scripts for build success
-        if: env.SHOULD_FAIL != 'true'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up Node for build success notification
-        if: env.SHOULD_FAIL != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: Notify CI wave about build success (single-platform flow)
         if: env.SHOULD_FAIL != 'true'
@@ -197,6 +183,23 @@ jobs:
 
           echo "SHOULD_FAIL=$SHOULD_FAIL" >> $GITHUB_ENV
 
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
       - name: Notify required build failure
         if: env.SHOULD_FAIL == 'true'
         uses: sarisia/actions-status-discord@v1
@@ -209,18 +212,6 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
-
-      - name: Check out notification scripts for required build failure
-        if: env.SHOULD_FAIL == 'true'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up Node for required build failure notification
-        if: env.SHOULD_FAIL == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: Notify CI wave about required build failure
         if: env.SHOULD_FAIL == 'true'
@@ -236,26 +227,6 @@ jobs:
           CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           CI_PIPELINES_SERVICE: desktop
         run: node scripts/notify-ci-wave.mjs
-
-      - name: Check out
-        if: env.SHOULD_FAIL != 'true'
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up pnpm
-        if: env.SHOULD_FAIL != 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
-          run_install: false
-
-      - name: Set up Node
-        if: env.SHOULD_FAIL != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
 
       - name: Install dependencies
         if: env.SHOULD_FAIL != 'true'

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -87,8 +87,8 @@ jobs:
         if: failure()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Signing failed ❌"
@@ -111,8 +111,8 @@ jobs:
         if: success()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Binaries Signed ✅"

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -89,6 +89,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Signing failed ❌"
@@ -113,6 +114,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Binaries Signed ✅"

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -92,7 +92,6 @@ jobs:
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Signing failed ❌"
-          CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
         run: node scripts/notify-ci-wave.mjs
 
@@ -118,6 +117,5 @@ jobs:
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "6529 Desktop - IPFS Binaries Signed ✅"
           CI_PIPELINES_DESCRIPTION: "Signed IPFS binaries uploaded to S3"
-          CI_PIPELINES_ENVIRONMENT: production
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
         run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -83,6 +83,19 @@ jobs:
           title: "6529 Desktop - IPFS Signing failed ❌"
           color: 0xff0000
 
+      - name: Notify CI wave about IPFS signing failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - IPFS Signing failed ❌"
+          CI_PIPELINES_ENVIRONMENT: production
+          CI_PIPELINES_SERVICE: desktop-ipfs-signing
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify Discord on success
         if: success()
         uses: sarisia/actions-status-discord@v1
@@ -94,3 +107,17 @@ jobs:
           title: "6529 Desktop - IPFS Binaries Signed ✅"
           description: "Signed IPFS binaries uploaded to S3"
           color: 0x00ff00
+
+      - name: Notify CI wave about IPFS signing success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: "6529 Desktop - IPFS Binaries Signed ✅"
+          CI_PIPELINES_DESCRIPTION: "Signed IPFS binaries uploaded to S3"
+          CI_PIPELINES_ENVIRONMENT: production
+          CI_PIPELINES_SERVICE: desktop-ipfs-signing
+        run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -114,6 +114,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Windows Signing failed ❌"

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -107,3 +107,18 @@ jobs:
           description: "ENV: ${{ inputs.env }} - v${{ inputs.version }}"
           content: "<@&1162355330798325861>"
           color: 0xff0000
+
+      - name: Notify CI wave about Windows signing failure
+        if: ${{ inputs.should_run && failure() }}
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ inputs.env }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: "6529 Desktop - Windows Signing failed ❌"
+          CI_PIPELINES_DESCRIPTION: "ENV: ${{ inputs.env }} - v${{ inputs.version }}"
+          CI_PIPELINES_SERVICE: desktop-windows-signing
+        run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -112,10 +112,8 @@ jobs:
         if: ${{ inputs.should_run && failure() }}
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_TARGET_ENV: ${{ inputs.env }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: "6529 Desktop - Windows Signing failed ❌"

--- a/ops/skills/desktop-pr-iteration/SKILL.md
+++ b/ops/skills/desktop-pr-iteration/SKILL.md
@@ -5,7 +5,9 @@ description: Open and iterate a 6529-core Electron desktop update pull request a
 
 # Desktop PR Iteration
 
-Carry a desktop renderer update from local validation through a draft PR and keep ownership until checks and review bots are satisfied.
+Carry a desktop renderer update from local validation through a normal
+ready-for-review PR and keep ownership until checks and review bots are
+satisfied.
 
 ## Before Commit
 
@@ -25,9 +27,11 @@ Update desktop renderer to latest web
 
 Push `pull-web` to `origin`. If local history contains checkpoint commits, squash or amend before push when that keeps review cleaner and does not lose useful merge metadata. Preserve subtree merge commits that record imported web history.
 
-## Draft PR
+## Pull Request
 
-Open a draft PR from `pull-web` against `main` in `6529-Collections/6529-core`, or update the existing open `pull-web` PR.
+Open a normal ready-for-review PR from `pull-web` against `main` in
+`6529-Collections/6529-core`, or update the existing open `pull-web` PR. Use a
+draft PR only when the user explicitly asks for a draft PR in the current task.
 
 Include:
 
@@ -47,7 +51,8 @@ Include:
 - When coordinating in the 6529 Dev Daily Standup wave, post as `punk6529bot` with real 6529 mention metadata. A visible `@[handle]` in text is not enough; the drop payload also needs `mentioned_users` entries with `mentioned_profile_id` and `handle_in_content`.
 - The 6529bot responsiveness harness runs the repository root `./bin/6529 run dev` on Ubuntu and expects the renderer web app at `PORT=3001`. Preserve the narrow bot-server branch in `bin/6529` that delegates this path to `renderer/`; it detects either `REVIEWBOT_RESPONSIVENESS_OUTPUT_DIR` or the generated Playwright server env (`PORT_SEARCH_LIMIT=1`, localhost `BASE_ENDPOINT`, prod API/WS endpoints, `ASSETS_FROM_S3=true`). That branch must run root `build-next-config` before entering `renderer/`, so Next loads the generated root `next.config.mjs` instead of trying to compile `next.config.ts` during the bot dev server start. The normal desktop dev path should still start Electron.
 - CodeQL may flag imported renderer media sinks after a web pull. Keep URL handling real, not cosmetic: sanitize audio/video source URLs through an allowlist before assigning `src`, remove unnecessary clickable links for untrusted iframe banners, and route server-side preview fetches through `fetchPublicUrl` instead of raw `fetch` when the request URL depends on preview metadata or user-submitted URLs. Inline CodeQL suppressions may not be honored by the PR gate, so prefer a guard path that the scanner can see or an explicit repository-level security decision.
-- Stop after CI and bots are happy, leaving the PR as draft unless the user explicitly asks to mark ready or merge.
+- Stop after CI and bots are happy. Do not merge unless the user explicitly
+  asks to merge.
 
 ## Closeout
 

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -2,12 +2,8 @@
 import crypto from 'node:crypto';
 
 const {
-  CI_PIPELINES_WAVE_WEBHOOK_URL,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET,
-  CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING,
-  CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD,
+  CI_PIPELINES_ALERT_URL,
+  CI_PIPELINES_ALERT_SECRET,
   CI_PIPELINES_TARGET_ENV,
   CI_PIPELINES_STATUS,
   CI_PIPELINES_TITLE,
@@ -31,50 +27,36 @@ function requireValue(name, value) {
   return value;
 }
 
-function resolveWebhookConfig() {
-  const targetEnv = (CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || '')
+function normalizeTargetEnvironment(value) {
+  const targetEnv = (value || '')
     .trim()
     .toLowerCase();
-  if (targetEnv === 'prod' || targetEnv === 'production') {
-    return {
-      targetEnv,
-      url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
-      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
-    };
+  if (!targetEnv) {
+    return null;
   }
-  if (targetEnv === 'staging') {
-    return {
-      targetEnv,
-      url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
-      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
-    };
+  if (
+    targetEnv === 'staging' ||
+    targetEnv === 'prod' ||
+    targetEnv === 'production'
+  ) {
+    return targetEnv;
   }
-  if (targetEnv) {
-    return {
-      targetEnv,
-      unsupported: true
-    };
-  }
-  return {
-    targetEnv: 'default',
-    url: CI_PIPELINES_WAVE_WEBHOOK_URL,
-    secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
-  };
+  return `unsupported:${targetEnv}`;
 }
 
-const webhookConfig = resolveWebhookConfig();
+const targetEnvironment = normalizeTargetEnvironment(
+  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT
+);
 
-if (webhookConfig.unsupported) {
+if (targetEnvironment?.startsWith('unsupported:')) {
   console.error(
-    `Unsupported CI pipeline wave target environment: ${webhookConfig.targetEnv}`
+    `Unsupported CI pipeline alert target environment: ${targetEnvironment.slice(12)}`
   );
   process.exit(1);
 }
 
-if (!webhookConfig.url || !webhookConfig.secret) {
-  console.log(
-    `CI pipeline wave webhook is not configured for ${webhookConfig.targetEnv}; skipping.`
-  );
+if (!CI_PIPELINES_ALERT_URL || !CI_PIPELINES_ALERT_SECRET) {
+  console.log('CI pipeline alert receiver is not configured; skipping.');
   process.exit(0);
 }
 
@@ -82,8 +64,6 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
-const targetEnvironment =
-  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || null;
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,
@@ -95,19 +75,19 @@ const payload = {
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,
-  environment: targetEnvironment,
+  environment: targetEnvironment || null,
   service: CI_PIPELINES_SERVICE || null
 };
 
 const body = Buffer.from(JSON.stringify(payload));
 const timestamp = Math.floor(Date.now() / 1000).toString();
 const signature = crypto
-  .createHmac('sha256', webhookConfig.secret)
+  .createHmac('sha256', CI_PIPELINES_ALERT_SECRET)
   .update(`${timestamp}.`)
   .update(body)
   .digest('hex');
 
-const response = await fetch(webhookConfig.url, {
+const response = await fetch(CI_PIPELINES_ALERT_URL, {
   method: 'POST',
   headers: {
     'content-type': 'application/json',

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+
+const {
+  CI_PIPELINES_WAVE_WEBHOOK_URL,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET,
+  CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING,
+  CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD,
+  CI_PIPELINES_TARGET_ENV,
+  CI_PIPELINES_STATUS,
+  CI_PIPELINES_TITLE,
+  CI_PIPELINES_DESCRIPTION,
+  CI_PIPELINES_ENVIRONMENT,
+  CI_PIPELINES_SERVICE,
+  CI_PIPELINES_WORKFLOW,
+  GITHUB_REPOSITORY,
+  GITHUB_WORKFLOW,
+  GITHUB_RUN_ID,
+  GITHUB_SERVER_URL = 'https://github.com',
+  GITHUB_SHA,
+  GITHUB_REF_NAME
+} = process.env;
+
+function requireValue(name, value) {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function resolveWebhookConfig() {
+  const targetEnv = (CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || '')
+    .trim()
+    .toLowerCase();
+  if (targetEnv === 'prod' || targetEnv === 'production') {
+    return {
+      url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
+      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
+    };
+  }
+  if (targetEnv === 'staging') {
+    return {
+      url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
+      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
+    };
+  }
+  return {
+    url: CI_PIPELINES_WAVE_WEBHOOK_URL,
+    secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
+  };
+}
+
+const webhookConfig = resolveWebhookConfig();
+
+if (!webhookConfig.url || !webhookConfig.secret) {
+  console.log('CI pipeline wave webhook is not configured; skipping.');
+  process.exit(0);
+}
+
+const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
+const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
+const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
+const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+
+const payload = {
+  repo: repository.split('/').pop() ?? repository,
+  workflow: CI_PIPELINES_WORKFLOW || GITHUB_WORKFLOW || 'GitHub Actions',
+  status,
+  title,
+  description: CI_PIPELINES_DESCRIPTION || null,
+  run_id: runId,
+  run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
+  sha: GITHUB_SHA || null,
+  branch: GITHUB_REF_NAME || null,
+  environment: CI_PIPELINES_ENVIRONMENT || CI_PIPELINES_TARGET_ENV || null,
+  service: CI_PIPELINES_SERVICE || null
+};
+
+const body = Buffer.from(JSON.stringify(payload));
+const timestamp = Math.floor(Date.now() / 1000).toString();
+const signature = crypto
+  .createHmac('sha256', webhookConfig.secret)
+  .update(`${timestamp}.`)
+  .update(body)
+  .digest('hex');
+
+const response = await fetch(webhookConfig.url, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'x-6529-ci-timestamp': timestamp,
+    'x-6529-ci-signature': `sha256=${signature}`
+  },
+  body
+});
+
+if (!response.ok) {
+  const errorText = await response.text();
+  throw new Error(
+    `CI pipeline wave notification failed: ${response.status} ${response.statusText} ${errorText}`
+  );
+}
+
+console.log('CI pipeline wave notification sent.');

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -36,17 +36,20 @@ function resolveWebhookConfig() {
     .toLowerCase();
   if (targetEnv === 'prod' || targetEnv === 'production') {
     return {
+      targetEnv,
       url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
     };
   }
   if (targetEnv === 'staging') {
     return {
+      targetEnv,
       url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
     };
   }
   return {
+    targetEnv: targetEnv || 'default',
     url: CI_PIPELINES_WAVE_WEBHOOK_URL,
     secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
   };
@@ -55,7 +58,9 @@ function resolveWebhookConfig() {
 const webhookConfig = resolveWebhookConfig();
 
 if (!webhookConfig.url || !webhookConfig.secret) {
-  console.log('CI pipeline wave webhook is not configured; skipping.');
+  console.log(
+    `CI pipeline wave webhook is not configured for ${webhookConfig.targetEnv}; skipping.`
+  );
   process.exit(0);
 }
 
@@ -97,10 +102,10 @@ const response = await fetch(webhookConfig.url, {
 });
 
 if (!response.ok) {
-  const errorText = await response.text();
-  throw new Error(
-    `CI pipeline wave notification failed: ${response.status} ${response.statusText} ${errorText}`
+  console.error(
+    `CI pipeline wave notification failed: ${response.status} ${response.statusText}`
   );
+  process.exit(1);
 }
 
 console.log('CI pipeline wave notification sent.');

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -25,7 +25,8 @@ const {
 
 function requireValue(name, value) {
   if (!value) {
-    throw new Error(`${name} is required`);
+    console.error(`${name} is required`);
+    process.exit(1);
   }
   return value;
 }
@@ -81,6 +82,8 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const targetEnvironment =
+  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || null;
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,
@@ -92,7 +95,7 @@ const payload = {
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,
-  environment: CI_PIPELINES_ENVIRONMENT || CI_PIPELINES_TARGET_ENV || null,
+  environment: targetEnvironment,
   service: CI_PIPELINES_SERVICE || null
 };
 

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -46,6 +46,15 @@ function normalizeTargetEnvironment(value) {
   return `unsupported:${targetEnv}`;
 }
 
+function getFetchFailureMessage(error) {
+  if (error instanceof Error) {
+    return error.name === 'AbortError'
+      ? 'request timed out'
+      : error.message;
+  }
+  return 'unknown request error';
+}
+
 const targetEnvironment = normalizeTargetEnvironment(
   CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT
 );
@@ -100,11 +109,25 @@ if (CI_PIPELINES_ALERT_API_AUTH) {
   headers['x-6529-auth'] = CI_PIPELINES_ALERT_API_AUTH;
 }
 
-const response = await fetch(CI_PIPELINES_ALERT_URL, {
-  method: 'POST',
-  headers,
-  body
-});
+const controller = new AbortController();
+const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+let response;
+try {
+  response = await fetch(CI_PIPELINES_ALERT_URL, {
+    method: 'POST',
+    headers,
+    body,
+    signal: controller.signal
+  });
+} catch (error) {
+  console.error(
+    `CI pipeline wave notification request failed: ${getFetchFailureMessage(error)}`
+  );
+  process.exit(1);
+} finally {
+  clearTimeout(timeoutId);
+}
 
 if (!response.ok) {
   console.error(

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -15,6 +15,7 @@ const {
   GITHUB_REPOSITORY,
   GITHUB_WORKFLOW,
   GITHUB_RUN_ID,
+  GITHUB_RUN_NUMBER,
   GITHUB_SERVER_URL = 'https://github.com',
   GITHUB_SHA,
   GITHUB_REF_NAME
@@ -73,6 +74,7 @@ const payload = {
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
   run_id: runId,
+  run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -48,14 +48,27 @@ function resolveWebhookConfig() {
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
     };
   }
+  if (targetEnv) {
+    return {
+      targetEnv,
+      unsupported: true
+    };
+  }
   return {
-    targetEnv: targetEnv || 'default',
+    targetEnv: 'default',
     url: CI_PIPELINES_WAVE_WEBHOOK_URL,
     secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
   };
 }
 
 const webhookConfig = resolveWebhookConfig();
+
+if (webhookConfig.unsupported) {
+  console.error(
+    `Unsupported CI pipeline wave target environment: ${webhookConfig.targetEnv}`
+  );
+  process.exit(1);
+}
 
 if (!webhookConfig.url || !webhookConfig.secret) {
   console.log(

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 const {
   CI_PIPELINES_ALERT_URL,
   CI_PIPELINES_ALERT_SECRET,
+  CI_PIPELINES_ALERT_API_AUTH,
   CI_PIPELINES_TARGET_ENV,
   CI_PIPELINES_STATUS,
   CI_PIPELINES_TITLE,
@@ -87,13 +88,19 @@ const signature = crypto
   .update(body)
   .digest('hex');
 
+const headers = {
+  'content-type': 'application/json',
+  'x-6529-ci-timestamp': timestamp,
+  'x-6529-ci-signature': `sha256=${signature}`
+};
+
+if (CI_PIPELINES_ALERT_API_AUTH) {
+  headers['x-6529-auth'] = CI_PIPELINES_ALERT_API_AUTH;
+}
+
 const response = await fetch(CI_PIPELINES_ALERT_URL, {
   method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'x-6529-ci-timestamp': timestamp,
-    'x-6529-ci-signature': `sha256=${signature}`
-  },
+  headers,
   body
 });
 


### PR DESCRIPTION
## Summary
- Adds the shared CI alert notification script.
- Mirrors desktop build/publish/signing/CloudFront Discord notifications into prod-hosted staging or production CI waves based on workflow inputs.
- Routes IPFS signing notifications to the prod-hosted `PROD-CI-PIPELINES` wave.

## Notes
- Uses one CI alert receiver (`vars.CI_PIPELINES_ALERT_URL` + `secrets.CI_PIPELINES_ALERT_SECRET`).
- Draft / DONT MERGE by request.
- CI was not awaited.
- No deploy performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional CI status notifications for build, publish, signing, and cloudfront steps, including clearer success and failure updates.
  * Improved PR workflow guidance so ready-for-review changes can be promoted without staying in draft by default.

* **Bug Fixes**
  * Made notification and release steps more reliable by ensuring required setup runs consistently before later stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->