### PR TITLE
Improve desktop CI wave notifications

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -127,7 +127,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build failed ❌"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build failed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build failed. Open the run for the failing job and logs."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -154,7 +154,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build completed ✅"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build completed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build completed successfully."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -223,7 +223,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} could not be published because at least one required platform build failed."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -299,7 +299,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed ✅"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish completed${{ github.event.inputs.env == 'Production' && ' with S3 and Arweave links published and CloudFront invalidated.' || ' with S3 links published.' }}"
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -327,7 +327,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish failed. Open the run to see whether S3, Arweave, or CloudFront failed."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -411,7 +411,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation completed ✅"
+          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation completed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront paths were invalidated successfully."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -439,7 +439,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation failed ❌"
+          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation failed"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront invalidation failed. Open the run for details."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -127,9 +127,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build failed ❌"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build failed. Open the run for the failing job and logs."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
       - name: Notify build success (single-platform flow)
@@ -153,9 +154,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "6529 Desktop - Build Success ✅"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} build completed ✅"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build completed successfully."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
   publish:
@@ -221,9 +223,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - Build failed ❌"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop Build All failed ❌"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} could not be published because at least one required platform build failed."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
       - name: Install dependencies
@@ -262,20 +265,6 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00bfff
 
-      - name: Notify CI wave about S3 links published
-        if: success() && env.SHOULD_FAIL != 'true'
-        continue-on-error: true
-        env:
-          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
-          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
-          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
-          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
-          CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "6529 Desktop - S3 links published ✅"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
-          CI_PIPELINES_SERVICE: desktop
-        run: node scripts/notify-ci-wave.mjs
-
       - name: Publish Arweave Links
         if: env.SHOULD_FAIL != 'true' && github.event.inputs.env == 'Production'
         env:
@@ -299,18 +288,21 @@ jobs:
           description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
           color: 0x00ff00
 
-      - name: Notify CI wave about final production build success
-        if: success() && env.SHOULD_FAIL != 'true' && github.event.inputs.env == 'Production'
+      # Send one wave update after every publish step has finished. Production
+      # includes Arweave and CloudFront; staging finishes after publishing S3 links.
+      - name: Notify CI wave about completed publish
+        if: success() && env.SHOULD_FAIL != 'true'
         continue-on-error: true
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
-          CI_PIPELINES_TARGET_ENV: production
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "6529 Desktop - Build complete 🚀"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed 🚀"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish completed${{ github.event.inputs.env == 'Production' && ' with S3 and Arweave links published and CloudFront invalidated.' || ' with S3 links published.' }}"
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
       - name: Notify Publish Failure
@@ -335,9 +327,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - Publish job failed ❌"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish failed. Open the run to see whether S3, Arweave, or CloudFront failed."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
       - name: Summary
@@ -418,9 +411,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidated ✅"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation completed ✅"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront paths were invalidated successfully."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs
 
       - name: Notify Failure
@@ -445,7 +439,8 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - CloudFront invalidation failed ❌"
-          CI_PIPELINES_DESCRIPTION: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop CloudFront invalidation failed ❌"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront invalidation failed. Open the run for details."
           CI_PIPELINES_SERVICE: desktop
+          CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -284,7 +284,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "Desktop ${{ github.event.inputs.flow }} completed 🚀"
+          title: "Desktop ${{ github.event.inputs.flow }} completed ✅"
           description: "Production v${{ github.event.inputs.version }} publish completed with S3 and Arweave links published and CloudFront invalidated."
           color: 0x00ff00
 
@@ -299,7 +299,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed 🚀"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed ✅"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish completed${{ github.event.inputs.env == 'Production' && ' with S3 and Arweave links published and CloudFront invalidated.' || ' with S3 links published.' }}"
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -339,7 +339,7 @@ jobs:
         with:
           script: |
             core.summary
-              .addHeading("6529 Desktop Build Complete 🚀")
+              .addHeading("6529 Desktop Build Complete ✅")
               .addTable([
                 ["FLOW", "${{ github.event.inputs.flow }}"],
                 ["Env", "${{ github.event.inputs.env }}"],

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -113,8 +113,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - Build failed ❌"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} build failed ❌"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build failed. Open the run for the failing job and logs."
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
@@ -141,8 +141,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "6529 Desktop - Build Success ✅"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} build completed ✅"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build completed successfully."
           color: 0x00ff00
 
       - name: Notify CI wave about build success (single-platform flow)
@@ -209,8 +209,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - Build failed ❌"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} could not be published because at least one required platform build failed."
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
@@ -223,7 +223,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop Build All failed ❌"
+          CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} failed ❌"
           CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} could not be published because at least one required platform build failed."
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
@@ -261,8 +261,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "6529 Desktop - S3 links published ✅"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} S3 links published ☁️"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} S3 download links are available."
           color: 0x00bfff
 
       - name: Publish Arweave Links
@@ -284,8 +284,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "6529 Desktop - Build complete 🚀"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} completed 🚀"
+          description: "Production v${{ github.event.inputs.version }} publish completed with S3 and Arweave links published and CloudFront invalidated."
           color: 0x00ff00
 
       # Send one wave update after every publish step has finished. Production
@@ -313,8 +313,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - Publish job failed ❌"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish failed. Open the run to see whether S3, Arweave, or CloudFront failed."
           content: "<@&1162355330798325861>"
           color: 0xff0000
 
@@ -398,8 +398,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "6529 Desktop - CloudFront invalidated ✅"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop CloudFront invalidation completed ✅"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront paths were invalidated successfully."
           color: 0x00bfff
 
       - name: Notify CI wave about CloudFront invalidation success
@@ -425,8 +425,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - CloudFront invalidation failed ❌"
-          description: "FLOW: ${{ github.event.inputs.flow }} / ENV: ${{ github.event.inputs.env }} - v${{ github.event.inputs.version }}"
+          title: "Desktop CloudFront invalidation failed ❌"
+          description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront invalidation failed. Open the run for details."
           content: "<@&1162355330798325861>"
           color: 0xff0000
 

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -93,7 +93,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop IPFS signing failed ❌"
+          CI_PIPELINES_TITLE: "Desktop IPFS signing failed"
           CI_PIPELINES_DESCRIPTION: "Signing or uploading the Windows IPFS binaries failed. Open the run for the failing step and logs."
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
           CI_PIPELINES_WORKFLOW: Sign IPFS Binaries
@@ -120,7 +120,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "Desktop IPFS signing completed ✅"
+          CI_PIPELINES_TITLE: "Desktop IPFS signing completed"
           CI_PIPELINES_DESCRIPTION: "Signed Windows IPFS binaries were uploaded to S3 successfully."
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
           CI_PIPELINES_WORKFLOW: Sign IPFS Binaries

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -92,8 +92,10 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - IPFS Signing failed ❌"
+          CI_PIPELINES_TITLE: "Desktop IPFS signing failed ❌"
+          CI_PIPELINES_DESCRIPTION: "Signing or uploading the Windows IPFS binaries failed. Open the run for the failing step and logs."
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
+          CI_PIPELINES_WORKFLOW: Sign IPFS Binaries
         run: node scripts/notify-ci-wave.mjs
 
       - name: Notify Discord on success
@@ -117,7 +119,8 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: production
           CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: "6529 Desktop - IPFS Binaries Signed ✅"
-          CI_PIPELINES_DESCRIPTION: "Signed IPFS binaries uploaded to S3"
+          CI_PIPELINES_TITLE: "Desktop IPFS signing completed ✅"
+          CI_PIPELINES_DESCRIPTION: "Signed Windows IPFS binaries were uploaded to S3 successfully."
           CI_PIPELINES_SERVICE: desktop-ipfs-signing
+          CI_PIPELINES_WORKFLOW: Sign IPFS Binaries
         run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -80,7 +80,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - IPFS Signing failed ❌"
+          title: "Desktop IPFS signing failed ❌"
+          description: "Signing or uploading the Windows IPFS binaries failed. Open the run for the failing step and logs."
           color: 0xff0000
 
       - name: Notify CI wave about IPFS signing failure
@@ -106,8 +107,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: success
-          title: "6529 Desktop - IPFS Binaries Signed ✅"
-          description: "Signed IPFS binaries uploaded to S3"
+          title: "Desktop IPFS signing completed ✅"
+          description: "Signed Windows IPFS binaries were uploaded to S3 successfully."
           color: 0x00ff00
 
       - name: Notify CI wave about IPFS signing success

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -117,7 +117,7 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "Desktop Windows signing failed ❌"
+          CI_PIPELINES_TITLE: "Desktop Windows signing failed"
           CI_PIPELINES_DESCRIPTION: "${{ inputs.env }} v${{ inputs.version }} signing or signed-artifact upload failed. Open the run for details."
           CI_PIPELINES_SERVICE: desktop-windows-signing
           CI_PIPELINES_WORKFLOW: Sign Windows

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -103,8 +103,8 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "6529 Desktop - Windows Signing failed ❌"
-          description: "ENV: ${{ inputs.env }} - v${{ inputs.version }}"
+          title: "Desktop Windows signing failed ❌"
+          description: "${{ inputs.env }} v${{ inputs.version }} signing or signed-artifact upload failed. Open the run for details."
           content: "<@&1162355330798325861>"
           color: 0xff0000
 

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -117,7 +117,8 @@ jobs:
           CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ inputs.env }}
           CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: "6529 Desktop - Windows Signing failed ❌"
-          CI_PIPELINES_DESCRIPTION: "ENV: ${{ inputs.env }} - v${{ inputs.version }}"
+          CI_PIPELINES_TITLE: "Desktop Windows signing failed ❌"
+          CI_PIPELINES_DESCRIPTION: "${{ inputs.env }} v${{ inputs.version }} signing or signed-artifact upload failed. Open the run for details."
           CI_PIPELINES_SERVICE: desktop-windows-signing
+          CI_PIPELINES_WORKFLOW: Sign Windows
         run: node scripts/notify-ci-wave.mjs


### PR DESCRIPTION
## Summary

- report the selected desktop flow (for example `Publish` or `Linux`) as the CI-wave workflow instead of the generic workflow file name
- include meaningful environment, version, outcome, and next-step details in every desktop CI-wave notification
- consolidate Publish into one final CI-wave success after all applicable S3, Arweave, and CloudFront steps complete, while preserving the useful intermediate Discord update
- give the standalone IPFS and Windows signing notifications explicit workflow names and actionable descriptions

## Validation

- parsed all GitHub Actions workflow YAML files
- `./bin/6529 run type-check`

No desktop binaries were built or published; this PR changes notification workflow configuration only.