### PR TITLE
Simplify desktop CI wave descriptions

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -300,7 +300,7 @@ jobs:
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.env }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: "Desktop ${{ github.event.inputs.flow }} completed"
-          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish completed${{ github.event.inputs.env == 'Production' && ' with S3 and Arweave links published and CloudFront invalidated.' || ' with S3 links published.' }}"
+          CI_PIPELINES_DESCRIPTION: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} ${{ github.event.inputs.env == 'Production' && 'Arweave links published' || 'S3 links published' }}"
           CI_PIPELINES_SERVICE: desktop
           CI_PIPELINES_WORKFLOW: ${{ github.event.inputs.flow }}
         run: node scripts/notify-ci-wave.mjs


### PR DESCRIPTION
## Issue
- Desktop publish wave posts use verbose completion text and combine unrelated delivery details.

## Fix
- Report the artifact milestone relevant to each environment in concise wording.

## Changes
- Staging publishes report `Staging v<version> S3 links published`.
- Production publishes report `Production v<version> Arweave links published`.

## Validation
- Parsed the modified workflow file as YAML.
- Verified the diff has no whitespace errors.

## Risk
- Level: Low
- Why: Notification text only; desktop build and publishing behavior is unchanged.
- Rollback: Revert the workflow description expression.

## Review Notes
- Confirm staging and production select the intended text through the existing environment condition.