### PR TITLE
Send initiators with desktop CI alerts

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -113,7 +113,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop ${{ github.event.inputs.flow }} build failed ❌"
+          title: "Desktop ${{ github.event.inputs.flow }} build failed 🚨"
           description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} build failed. Open the run for the failing job and logs."
           content: "<@&1162355330798325861>"
           color: 0xff0000
@@ -209,7 +209,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          title: "Desktop ${{ github.event.inputs.flow }} failed 🚨"
           description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} could not be published because at least one required platform build failed."
           content: "<@&1162355330798325861>"
           color: 0xff0000
@@ -313,7 +313,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop ${{ github.event.inputs.flow }} failed ❌"
+          title: "Desktop ${{ github.event.inputs.flow }} failed 🚨"
           description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} publish failed. Open the run to see whether S3, Arweave, or CloudFront failed."
           content: "<@&1162355330798325861>"
           color: 0xff0000
@@ -425,7 +425,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop CloudFront invalidation failed ❌"
+          title: "Desktop CloudFront invalidation failed 🚨"
           description: "${{ github.event.inputs.env }} v${{ github.event.inputs.version }} CloudFront invalidation failed. Open the run for details."
           content: "<@&1162355330798325861>"
           color: 0xff0000

--- a/.github/workflows/sign-ipfs.yml
+++ b/.github/workflows/sign-ipfs.yml
@@ -80,7 +80,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop IPFS signing failed ❌"
+          title: "Desktop IPFS signing failed 🚨"
           description: "Signing or uploading the Windows IPFS binaries failed. Open the run for the failing step and logs."
           color: 0xff0000
 

--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -103,7 +103,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           status: failure
-          title: "Desktop Windows signing failed ❌"
+          title: "Desktop Windows signing failed 🚨"
           description: "${{ inputs.env }} v${{ inputs.version }} signing or signed-artifact upload failed. Open the run for details."
           content: "<@&1162355330798325861>"
           color: 0xff0000

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -18,7 +18,9 @@ const {
   GITHUB_RUN_NUMBER,
   GITHUB_SERVER_URL = 'https://github.com',
   GITHUB_SHA,
-  GITHUB_REF_NAME
+  GITHUB_REF_NAME,
+  GITHUB_TRIGGERING_ACTOR,
+  GITHUB_ACTOR
 } = process.env;
 
 function requireValue(name, value) {
@@ -75,6 +77,10 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const triggeredByGithubLogin = requireValue(
+  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
+  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
+);
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,
@@ -82,6 +88,7 @@ const payload = {
   status,
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
+  triggered_by_github_login: triggeredByGithubLogin,
   run_id: runId,
   run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -77,10 +77,7 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
-const triggeredByGithubLogin = requireValue(
-  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
-  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
-);
+const triggeredByGithubLogin = GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR || null;
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,


### PR DESCRIPTION
## Summary

- send the current GitHub triggering actor with every desktop CI Wave alert when available
- keep alert delivery working when GitHub actor metadata is unavailable
- replace CI failure notification markers from ❌ to 🚨
- preserve all existing desktop alert descriptions

## Root cause

Desktop CI alerts did not include the workflow initiator, so the resulting Wave post could not create a real 6529 profile mention.

## Impact

After [backend PR #1760](https://github.com/6529-Collections/6529seize-backend/pull/1760) is deployed, desktop CI posts will tag the initiating 6529 profile when resolvable and show `Initiated by: unknown` otherwise. Existing build, signing, publishing, and CloudFront descriptions remain intact.

Backend PR #1760 must be deployed before this sender change is used.

## Validation

- sender syntax check
- signed payload execution checks with and without actor metadata, confirming Core descriptions are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Notifications**
  * Improved CI and deployment failure alerts with clearer 🚨 warning indicators.
  * CI wave notifications now include the GitHub account that triggered the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->