### PR TITLE
v0.3.12

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -302,7 +302,8 @@ jobs:
           CONFIG=$(node -e "console.log(JSON.stringify(require('./electron-builder.production.json').publish[0]))")
           BUCKET=$(echo "$CONFIG" | jq -r '.bucket')
           REGION=$(echo "$CONFIG" | jq -r '.region')
-          PATH_PREFIX=$(echo "$CONFIG" | jq -r '.path' | sed 's|\${os}|mac|')
+          RAW_PATH=$(echo "$CONFIG" | jq -r '.path')
+          PATH_PREFIX=$(node scripts/resolve-s3-publish-prefix.cjs "$RAW_PATH" mac)
 
           echo "bucket=$BUCKET" >> $GITHUB_OUTPUT
           echo "region=$REGION" >> $GITHUB_OUTPUT

--- a/electron-builder.local.json
+++ b/electron-builder.local.json
@@ -92,6 +92,16 @@
       }
     ],
     "artifactName": "6529-DESKTOP-LOCAL-linux-${arch}-${version}.${ext}",
+    "desktop": {
+      "entry": {
+        "Name": "6529 Desktop Local",
+        "Type": "Application",
+        "Terminal": "false",
+        "MimeType": "x-scheme-handler/localcore6529;",
+        "Categories": "Utility;Network;",
+        "Comment": "6529 Desktop Local Application"
+      }
+    },
     "protocols": [
       {
         "name": "6529 Desktop Local Protocol",

--- a/electron-builder.production-mac-arm64.json
+++ b/electron-builder.production-mac-arm64.json
@@ -35,7 +35,7 @@
       "provider": "s3",
       "bucket": "6529bucket",
       "region": "eu-west-1",
-      "path": "6529-core-app/${os}/",
+      "path": "6529-core-app/${os}",
       "acl": null
     },
     {

--- a/electron-builder.production-mac-x64.json
+++ b/electron-builder.production-mac-x64.json
@@ -35,7 +35,7 @@
       "provider": "s3",
       "bucket": "6529bucket",
       "region": "eu-west-1",
-      "path": "6529-core-app/${os}/",
+      "path": "6529-core-app/${os}",
       "acl": null
     },
     {

--- a/electron-builder.production.json
+++ b/electron-builder.production.json
@@ -118,6 +118,16 @@
       }
     ],
     "artifactName": "6529-DESKTOP-linux-${arch}-${version}.${ext}",
+    "desktop": {
+      "entry": {
+        "Name": "6529 Desktop",
+        "Type": "Application",
+        "Terminal": "false",
+        "MimeType": "x-scheme-handler/core6529;",
+        "Categories": "Utility;Network;",
+        "Comment": "6529 Desktop Application"
+      }
+    },
     "protocols": [
       {
         "name": "6529 Desktop Protocol",

--- a/electron-builder.production.json
+++ b/electron-builder.production.json
@@ -35,7 +35,7 @@
       "provider": "s3",
       "bucket": "6529bucket",
       "region": "eu-west-1",
-      "path": "6529-core-app/${os}/",
+      "path": "6529-core-app/${os}",
       "acl": null
     },
     {

--- a/electron-builder.staging.json
+++ b/electron-builder.staging.json
@@ -35,7 +35,7 @@
       "provider": "s3",
       "bucket": "6529bucket",
       "region": "eu-west-1",
-      "path": "6529-staging-core-app/${os}/",
+      "path": "6529-staging-core-app/${os}",
       "acl": null
     },
     {

--- a/electron-builder.staging.json
+++ b/electron-builder.staging.json
@@ -106,6 +106,16 @@
       }
     ],
     "artifactName": "6529-DESKTOP-STAGING-linux-${arch}-${version}.${ext}",
+    "desktop": {
+      "entry": {
+        "Name": "6529 Desktop Staging",
+        "Type": "Application",
+        "Terminal": "false",
+        "MimeType": "x-scheme-handler/stagingcore6529;",
+        "Categories": "Utility;Network;",
+        "Comment": "6529 Desktop Staging Application"
+      }
+    },
     "protocols": [
       {
         "name": "6529 Desktop Staging Protocol",

--- a/electron-src/linux-desktop-config.test.ts
+++ b/electron-src/linux-desktop-config.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+interface ElectronBuilderConfig {
+  linux?: {
+    desktop?: {
+      entry?: Record<string, string>;
+    };
+  };
+}
+
+const EXPECTED_DESKTOP_ENTRIES = {
+  "electron-builder.local.json": {
+    Name: "6529 Desktop Local",
+    Type: "Application",
+    Terminal: "false",
+    MimeType: "x-scheme-handler/localcore6529;",
+    Categories: "Utility;Network;",
+    Comment: "6529 Desktop Local Application",
+  },
+  "electron-builder.staging.json": {
+    Name: "6529 Desktop Staging",
+    Type: "Application",
+    Terminal: "false",
+    MimeType: "x-scheme-handler/stagingcore6529;",
+    Categories: "Utility;Network;",
+    Comment: "6529 Desktop Staging Application",
+  },
+  "electron-builder.production.json": {
+    Name: "6529 Desktop",
+    Type: "Application",
+    Terminal: "false",
+    MimeType: "x-scheme-handler/core6529;",
+    Categories: "Utility;Network;",
+    Comment: "6529 Desktop Application",
+  },
+} as const;
+
+describe("Linux desktop builder configuration", () => {
+  for (const [file, expectedEntry] of Object.entries(
+    EXPECTED_DESKTOP_ENTRIES,
+  )) {
+    it(`${file} uses the electron-builder v26 desktop entry shape`, () => {
+      const config = JSON.parse(
+        readFileSync(resolve(process.cwd(), file), "utf8"),
+      ) as ElectronBuilderConfig;
+
+      assert.deepEqual(config.linux?.desktop?.entry, expectedEntry);
+    });
+  }
+});

--- a/electron-src/publish-config.test.ts
+++ b/electron-src/publish-config.test.ts
@@ -3,6 +3,12 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 
+const { resolveS3PublishPrefix } = require(
+  "../scripts/resolve-s3-publish-prefix.cjs",
+) as {
+  resolveS3PublishPrefix: (pathTemplate: string, os: string) => string;
+};
+
 interface PublishProvider {
   provider: string;
   path?: string;
@@ -19,6 +25,8 @@ const EXPECTED_S3_PATHS = {
   "electron-builder.production-mac-x64.json": "6529-core-app/${os}",
 } as const;
 
+const TEST_ARTIFACT = "6529-DESKTOP-mac-arm64-0.3.12.zip";
+
 describe("desktop publish configuration", () => {
   for (const [file, expectedPath] of Object.entries(EXPECTED_S3_PATHS)) {
     it(`${file} uses a normalized S3 publish path`, () => {
@@ -32,6 +40,39 @@ describe("desktop publish configuration", () => {
       assert.ok(s3Provider, `${file} must configure an S3 publisher`);
       assert.equal(s3Provider.path, expectedPath);
       assert.equal(s3Provider.path?.endsWith("/"), false);
+
+      const platformPath = expectedPath.replace("${os}", "mac");
+      assert.equal(
+        `${s3Provider.path.replace("${os}", "mac")}/${TEST_ARTIFACT}`,
+        `${platformPath}/${TEST_ARTIFACT}`,
+      );
+      assert.equal(
+        `${resolveS3PublishPrefix(expectedPath, "mac")}${TEST_ARTIFACT}`,
+        `${platformPath}/${TEST_ARTIFACT}`,
+      );
     });
   }
+
+  it("normalizes manual upload prefixes to exactly one trailing slash", () => {
+    assert.equal(
+      resolveS3PublishPrefix("6529-core-app/${os}", "mac"),
+      "6529-core-app/mac/",
+    );
+    assert.equal(
+      resolveS3PublishPrefix("6529-core-app/${os}//", "mac"),
+      "6529-core-app/mac/",
+    );
+  });
+
+  it("routes the production macOS workflow through the tested prefix resolver", () => {
+    const workflow = readFileSync(
+      resolve(process.cwd(), ".github", "workflows", "build-mac.yml"),
+      "utf8",
+    );
+
+    assert.match(
+      workflow,
+      /PATH_PREFIX=\$\(node scripts\/resolve-s3-publish-prefix\.cjs "\$RAW_PATH" mac\)/,
+    );
+  });
 });

--- a/electron-src/publish-config.test.ts
+++ b/electron-src/publish-config.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+interface PublishProvider {
+  provider: string;
+  path?: string;
+}
+
+interface ElectronBuilderConfig {
+  publish?: PublishProvider[];
+}
+
+const EXPECTED_S3_PATHS = {
+  "electron-builder.staging.json": "6529-staging-core-app/${os}",
+  "electron-builder.production.json": "6529-core-app/${os}",
+  "electron-builder.production-mac-arm64.json": "6529-core-app/${os}",
+  "electron-builder.production-mac-x64.json": "6529-core-app/${os}",
+} as const;
+
+describe("desktop publish configuration", () => {
+  for (const [file, expectedPath] of Object.entries(EXPECTED_S3_PATHS)) {
+    it(`${file} uses a normalized S3 publish path`, () => {
+      const config = JSON.parse(
+        readFileSync(resolve(process.cwd(), file), "utf8"),
+      ) as ElectronBuilderConfig;
+      const s3Provider = config.publish?.find(
+        ({ provider }) => provider === "s3",
+      );
+
+      assert.ok(s3Provider, `${file} must configure an S3 publisher`);
+      assert.equal(s3Provider.path, expectedPath);
+      assert.equal(s3Provider.path?.endsWith("/"), false);
+    });
+  }
+});

--- a/electron-src/wallet-auth-flow.test.ts
+++ b/electron-src/wallet-auth-flow.test.ts
@@ -20,6 +20,7 @@ import {
   CONNECTOR_MODAL_BODY_CLASS,
   CONNECTOR_MODAL_DIALOG_CLASS,
 } from "../renderer/components/header/user/connector-modal-layout";
+import { completeConnectorSelection } from "../renderer/components/header/user/complete-connector-selection";
 import { getSeedWalletSelectionState } from "../renderer/components/header/user/seed-wallet-selection-state";
 import { CORE_WALLET_MODAL_SIZE_CLASS } from "../renderer/components/shared/core-wallet-modal-layout";
 import {
@@ -144,6 +145,31 @@ describe("desktop wallet authentication flow", () => {
       }),
       "available",
     );
+  });
+
+  it("makes a selected Core wallet authoritative before closing the chooser", async () => {
+    const selectedAddress = "0x2222222222222222222222222222222222222222";
+    const events: string[] = [];
+    let resolveConnection: (() => void) | undefined;
+    const connection = new Promise<void>((resolve) => {
+      resolveConnection = resolve;
+    });
+
+    const selection = completeConnectorSelection({
+      connect: () => connection,
+      seedWalletAddress: selectedAddress,
+      acceptConnection: (address) => events.push(`accept:${address}`),
+      select: () => events.push("close"),
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(events, []);
+
+    assert.ok(resolveConnection);
+    resolveConnection();
+    await selection;
+
+    assert.deepEqual(events, [`accept:${selectedAddress}`, "close"]);
   });
 
   it("keeps Core wallet modals in the same responsive size envelope", () => {

--- a/electron-src/wallet-auth-flow.test.ts
+++ b/electron-src/wallet-auth-flow.test.ts
@@ -195,6 +195,7 @@ describe("desktop wallet authentication flow", () => {
     });
 
     const selection = startFreshBrowserConnectorSelection({
+      beginHandoff: () => events.push("protect-active-profile"),
       select: () => events.push("close"),
       reset: async () => {
         events.push("reset");
@@ -203,16 +204,51 @@ describe("desktop wallet authentication flow", () => {
       connect: async () => {
         events.push("connect");
       },
+      endHandoff: () => events.push("restore-active-profile"),
     });
 
     await Promise.resolve();
-    assert.deepEqual(events, ["close", "reset"]);
+    assert.deepEqual(events, ["protect-active-profile", "close", "reset"]);
 
     assert.ok(resolveReset);
     resolveReset();
     await selection;
 
-    assert.deepEqual(events, ["close", "reset", "connect"]);
+    assert.deepEqual(events, [
+      "protect-active-profile",
+      "close",
+      "reset",
+      "connect",
+      "restore-active-profile",
+    ]);
+  });
+
+  it("restores the active profile when browser reconnection fails", async () => {
+    const events: string[] = [];
+
+    await assert.rejects(
+      startFreshBrowserConnectorSelection({
+        beginHandoff: () => events.push("protect-active-profile"),
+        select: () => events.push("close"),
+        reset: async () => {
+          events.push("reset");
+        },
+        connect: async () => {
+          events.push("connect");
+          throw new Error("browser connection failed");
+        },
+        endHandoff: () => events.push("restore-active-profile"),
+      }),
+      /browser connection failed/,
+    );
+
+    assert.deepEqual(events, [
+      "protect-active-profile",
+      "close",
+      "reset",
+      "connect",
+      "restore-active-profile",
+    ]);
   });
 
   it("keeps Core wallet modals in the same responsive size envelope", () => {

--- a/electron-src/wallet-auth-flow.test.ts
+++ b/electron-src/wallet-auth-flow.test.ts
@@ -35,6 +35,10 @@ import {
 import {
   selectLiveWalletAccount,
 } from "../renderer/components/auth/selectLiveWalletAccount";
+import {
+  openDesktopAddConnectorChooser,
+  shouldReconcileConnectorState,
+} from "../renderer/components/auth/connector-selection-lifecycle";
 
 describe("desktop wallet authentication flow", () => {
   it("keeps Core wallet unlock and request prompts above authentication", () => {
@@ -43,6 +47,64 @@ describe("desktop wallet authentication flow", () => {
     assert.equal(NON_WALLET_MODAL_OVERLAY_CLASS, "tw-z-[9990]");
     assert.equal(AUTHENTICATION_MODAL_OVERLAY_CLASS, "tw-z-[10000]");
     assert.equal(WALLET_REQUEST_MODAL_OVERLAY_CLASS, "tw-z-[10010]");
+  });
+
+  it("keeps an active Browser profile stable when Add opens over stale Wagmi state", () => {
+    const activeBrowserAddress = "0x1111111111111111111111111111111111111111";
+    const staleWagmiAddress = "0x2222222222222222222222222222222222222222";
+    const events: string[] = [];
+    let activeAddress = activeBrowserAddress;
+    let isAddingConnectedAccount = true;
+    let isConnectorChooserOpen = false;
+
+    openDesktopAddConnectorChooser({
+      clearAddCandidate: () => events.push("clear-candidate"),
+      setAddingConnectedAccount: (isAdding) => {
+        isAddingConnectedAccount = isAdding;
+        events.push(`adding:${isAdding}`);
+      },
+      openChooser: () => {
+        isConnectorChooserOpen = true;
+        events.push("open-chooser");
+      },
+    });
+
+    const shouldReconcile = shouldReconcileConnectorState({
+      isSigningOutAll: false,
+      isBrowserConnectorHandoff: false,
+      isConnectorChooserOpen,
+    });
+    if (shouldReconcile || isAddingConnectedAccount) {
+      activeAddress = staleWagmiAddress;
+    }
+
+    assert.equal(activeAddress, activeBrowserAddress);
+    assert.equal(isAddingConnectedAccount, false);
+    assert.equal(shouldReconcile, false);
+    assert.deepEqual(events, [
+      "clear-candidate",
+      "adding:false",
+      "open-chooser",
+    ]);
+  });
+
+  it("resumes connector reconciliation only after chooser and handoff guards clear", () => {
+    assert.equal(
+      shouldReconcileConnectorState({
+        isSigningOutAll: false,
+        isBrowserConnectorHandoff: false,
+        isConnectorChooserOpen: false,
+      }),
+      true,
+    );
+    assert.equal(
+      shouldReconcileConnectorState({
+        isSigningOutAll: false,
+        isBrowserConnectorHandoff: true,
+        isConnectorChooserOpen: false,
+      }),
+      false,
+    );
   });
 
   it("rejects malformed Core wallet addresses", () => {

--- a/electron-src/wallet-auth-flow.test.ts
+++ b/electron-src/wallet-auth-flow.test.ts
@@ -20,7 +20,10 @@ import {
   CONNECTOR_MODAL_BODY_CLASS,
   CONNECTOR_MODAL_DIALOG_CLASS,
 } from "../renderer/components/header/user/connector-modal-layout";
-import { completeConnectorSelection } from "../renderer/components/header/user/complete-connector-selection";
+import {
+  completeConnectorSelection,
+  ConnectorSelectionGuard,
+} from "../renderer/components/header/user/complete-connector-selection";
 import { getSeedWalletSelectionState } from "../renderer/components/header/user/seed-wallet-selection-state";
 import { CORE_WALLET_MODAL_SIZE_CLASS } from "../renderer/components/shared/core-wallet-modal-layout";
 import {
@@ -170,6 +173,17 @@ describe("desktop wallet authentication flow", () => {
     await selection;
 
     assert.deepEqual(events, [`accept:${selectedAddress}`, "close"]);
+  });
+
+  it("allows only one connector selection at a time", () => {
+    const selectionGuard = new ConnectorSelectionGuard();
+
+    assert.equal(selectionGuard.tryAcquire(), true);
+    assert.equal(selectionGuard.tryAcquire(), false);
+
+    selectionGuard.release();
+
+    assert.equal(selectionGuard.tryAcquire(), true);
   });
 
   it("keeps Core wallet modals in the same responsive size envelope", () => {

--- a/electron-src/wallet-auth-flow.test.ts
+++ b/electron-src/wallet-auth-flow.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   completeConnectorSelection,
   ConnectorSelectionGuard,
+  startFreshBrowserConnectorSelection,
 } from "../renderer/components/header/user/complete-connector-selection";
 import { getSeedWalletSelectionState } from "../renderer/components/header/user/seed-wallet-selection-state";
 import { CORE_WALLET_MODAL_SIZE_CLASS } from "../renderer/components/shared/core-wallet-modal-layout";
@@ -184,6 +185,34 @@ describe("desktop wallet authentication flow", () => {
     selectionGuard.release();
 
     assert.equal(selectionGuard.tryAcquire(), true);
+  });
+
+  it("closes the chooser before resetting and reconnecting a browser connector", async () => {
+    const events: string[] = [];
+    let resolveReset: (() => void) | undefined;
+    const reset = new Promise<void>((resolve) => {
+      resolveReset = resolve;
+    });
+
+    const selection = startFreshBrowserConnectorSelection({
+      select: () => events.push("close"),
+      reset: async () => {
+        events.push("reset");
+        await reset;
+      },
+      connect: async () => {
+        events.push("connect");
+      },
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(events, ["close", "reset"]);
+
+    assert.ok(resolveReset);
+    resolveReset();
+    await selection;
+
+    assert.deepEqual(events, ["close", "reset", "connect"]);
   });
 
   it("keeps Core wallet modals in the same responsive size envelope", () => {

--- a/ops/skills/desktop-pr-iteration/SKILL.md
+++ b/ops/skills/desktop-pr-iteration/SKILL.md
@@ -20,7 +20,9 @@ satisfied.
   AppKit, disconnect the current provider, or switch/activate any account.
   Confirm explicit active-account storage remains authoritative while connector
   metadata reconciles, including an active browser wallet with stale Core
-  state still reported by Wagmi.
+  state still reported by Wagmi. When an active Browser connector is reset for
+  another Browser connection, suppress Wagmi's temporary fallback connector
+  for the entire external handoff so it cannot become the active profile.
 - Confirm local evidence is ready: current web SHA, install result, checks, Windows build/package result, and artifact path or blocker.
 - Stage only intended files. A renderer subtree sync can be large; inspect the summary and any root files carefully.
 - Use `codex-diff-check` on Windows.

--- a/ops/skills/desktop-pr-iteration/SKILL.md
+++ b/ops/skills/desktop-pr-iteration/SKILL.md
@@ -18,6 +18,8 @@ satisfied.
 - Run the Core-owned desktop renderer contract guard and restore any desktop adaptation it reports instead of weakening the guard.
 - Confirm Add only opens the Electron connector chooser: it must not wait for
   AppKit, disconnect the current provider, or switch/activate any account.
+  Opening the chooser must leave generic add-candidate reconciliation disabled;
+  only an explicit connector selection may arm or change connection authority.
   Confirm explicit active-account storage remains authoritative while connector
   metadata reconciles, including an active browser wallet with stale Core
   state still reported by Wagmi. When an active Browser connector is reset for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "6529-core",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": {
     "name": "6529",
     "email": "6529@6529.io"

--- a/renderer/components/auth/SeizeConnectProvider.tsx
+++ b/renderer/components/auth/SeizeConnectProvider.tsx
@@ -50,6 +50,7 @@ import {
   createAppKitModalBridgeStore,
   useAppKitModalBridgeState,
 } from "./AppKitModalBridge";
+import { openDesktopAddConnectorChooser } from "./connector-selection-lifecycle";
 import { WalletErrorBoundary } from "./error-boundary";
 import { SeizeConnectContext } from "./seizeConnectContextValue";
 import {
@@ -814,18 +815,21 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     // The desktop chooser can coexist with every connector. Opening Add must
     // never disconnect or activate a wallet before the user selects one.
     if (isElectron()) {
-      clearAddConnectedAccountGuard();
-      setIsAddingConnectedAccount(false);
       const storedOrigin = getWalletAddress();
       const addFlowOriginWallet =
         storedOrigin && isAddress(storedOrigin)
           ? getAddress(storedOrigin)
           : null;
-      openAddConnectedAccountModal(
-        clearAddConnectedAccountGuard,
-        addFlowOriginWallet,
-        signOutGeneration
-      );
+      openDesktopAddConnectorChooser({
+        clearAddCandidate: clearAddConnectedAccountGuard,
+        setAddingConnectedAccount: setIsAddingConnectedAccount,
+        openChooser: () =>
+          openAddConnectedAccountModal(
+            clearAddConnectedAccountGuard,
+            addFlowOriginWallet,
+            signOutGeneration
+          ),
+      });
       return;
     }
 

--- a/renderer/components/auth/SeizeConnectProvider.tsx
+++ b/renderer/components/auth/SeizeConnectProvider.tsx
@@ -815,14 +815,12 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     // never disconnect or activate a wallet before the user selects one.
     if (isElectron()) {
       clearAddConnectedAccountGuard();
+      setIsAddingConnectedAccount(false);
       const storedOrigin = getWalletAddress();
       const addFlowOriginWallet =
         storedOrigin && isAddress(storedOrigin)
           ? getAddress(storedOrigin)
           : null;
-      isAddingConnectedAccountRef.current = true;
-      addFlowOriginAddressRef.current = addFlowOriginWallet;
-      setIsAddingConnectedAccount(true);
       openAddConnectedAccountModal(
         clearAddConnectedAccountGuard,
         addFlowOriginWallet,

--- a/renderer/components/auth/SeizeConnectProvider.tsx
+++ b/renderer/components/auth/SeizeConnectProvider.tsx
@@ -793,13 +793,17 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     // never disconnect or activate a wallet before the user selects one.
     if (isElectron()) {
       clearAddConnectedAccountGuard();
-      setIsAddingConnectedAccount(false);
       const storedOrigin = getWalletAddress();
-      openAddConnectedAccountModal(
-        clearAddConnectedAccountGuard,
+      const addFlowOriginWallet =
         storedOrigin && isAddress(storedOrigin)
           ? getAddress(storedOrigin)
-          : null,
+          : null;
+      isAddingConnectedAccountRef.current = true;
+      addFlowOriginAddressRef.current = addFlowOriginWallet;
+      setIsAddingConnectedAccount(true);
+      openAddConnectedAccountModal(
+        clearAddConnectedAccountGuard,
+        addFlowOriginWallet,
         signOutGeneration
       );
       return;

--- a/renderer/components/auth/SeizeConnectProvider.tsx
+++ b/renderer/components/auth/SeizeConnectProvider.tsx
@@ -117,6 +117,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
   const retryConnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const connectIntentHandoffTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isAddingConnectedAccountRef = useRef(false);
+  const isBrowserConnectorHandoffRef = useRef(false);
   const isMountedRef = useRef(true);
   const { agentLoginImpersonatedAddress, impersonatedAddress } =
     getSeizeConnectImpersonation();
@@ -176,6 +177,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       retryConnectTimeoutRef.current = null;
     }
     isAddingConnectedAccountRef.current = false;
+    isBrowserConnectorHandoffRef.current = false;
     addFlowOriginAddressRef.current = null;
     setIsAddingConnectedAccount(false);
     clearBrowserConnectorConnectIntent();
@@ -272,6 +274,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     impersonatedAddress,
     isAddingConnectedAccount,
     isAddingConnectedAccountRef,
+    isBrowserConnectorHandoffRef,
     isConnectIntentWaitingForAppKit,
     isInitialized,
     isSigningOutAll,
@@ -546,6 +549,25 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     }
     setDisconnected();
   }, [refreshStoredConnectedAccounts, setConnected, setDisconnected]);
+
+  const seizeBeginBrowserConnectorHandoff = useCallback((): void => {
+    isBrowserConnectorHandoffRef.current = true;
+    isAddingConnectedAccountRef.current = false;
+    addFlowOriginAddressRef.current = null;
+    if (retryConnectTimeoutRef.current) {
+      clearTimeout(retryConnectTimeoutRef.current);
+      retryConnectTimeoutRef.current = null;
+    }
+    setIsAddingConnectedAccount(false);
+  }, []);
+
+  const seizeEndBrowserConnectorHandoff = useCallback((): void => {
+    isBrowserConnectorHandoffRef.current = false;
+    if (isSigningOutAllRef.current) {
+      return;
+    }
+    restoreStoredWalletState();
+  }, [isSigningOutAllRef, restoreStoredWalletState]);
 
   const seizeDisconnect = useCallback(async (): Promise<void> => {
     if (isSigningOutAllRef.current) {
@@ -1069,6 +1091,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       seizeDisconnectAndLogout,
       seizeDisconnectAndLogoutAll,
       seizeAcceptConnection,
+      seizeBeginBrowserConnectorHandoff,
+      seizeEndBrowserConnectorHandoff,
       seizeSwitchConnectedAccount,
       seizeAddConnectedAccount,
       isAddingConnectedAccount,
@@ -1108,6 +1132,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       seizeDisconnectAndLogout,
       seizeDisconnectAndLogoutAll,
       seizeAcceptConnection,
+      seizeBeginBrowserConnectorHandoff,
+      seizeEndBrowserConnectorHandoff,
       seizeSwitchConnectedAccount,
       seizeAddConnectedAccount,
       isConnectIntentWaitingForAppKit,

--- a/renderer/components/auth/connector-selection-lifecycle.ts
+++ b/renderer/components/auth/connector-selection-lifecycle.ts
@@ -1,0 +1,35 @@
+interface OpenDesktopAddConnectorChooserParams {
+  readonly clearAddCandidate: () => void;
+  readonly openChooser: () => void;
+  readonly setAddingConnectedAccount: (isAdding: boolean) => void;
+}
+
+interface ShouldReconcileConnectorStateParams {
+  readonly isBrowserConnectorHandoff: boolean;
+  readonly isConnectorChooserOpen: boolean;
+  readonly isSigningOutAll: boolean;
+}
+
+/** Opens Add without allowing existing connector state to become a candidate. */
+export function openDesktopAddConnectorChooser({
+  clearAddCandidate,
+  openChooser,
+  setAddingConnectedAccount,
+}: OpenDesktopAddConnectorChooserParams): void {
+  clearAddCandidate();
+  setAddingConnectedAccount(false);
+  openChooser();
+}
+
+/** Connector state must remain passive while the user is choosing a wallet. */
+export function shouldReconcileConnectorState({
+  isBrowserConnectorHandoff,
+  isConnectorChooserOpen,
+  isSigningOutAll,
+}: ShouldReconcileConnectorStateParams): boolean {
+  return !(
+    isSigningOutAll ||
+    isBrowserConnectorHandoff ||
+    isConnectorChooserOpen
+  );
+}

--- a/renderer/components/auth/seizeConnectEffects.ts
+++ b/renderer/components/auth/seizeConnectEffects.ts
@@ -34,6 +34,7 @@ interface SeizeConnectProviderEffectsParams {
   readonly impersonatedAddress: string | undefined;
   readonly isAddingConnectedAccount: boolean;
   readonly isAddingConnectedAccountRef: RefObject<boolean>;
+  readonly isBrowserConnectorHandoffRef: RefObject<boolean>;
   readonly isConnectIntentWaitingForAppKit: boolean;
   readonly isInitialized: boolean;
   readonly isSigningOutAll: boolean;
@@ -324,6 +325,7 @@ export function useSeizeConnectProviderEffects({
   impersonatedAddress,
   isAddingConnectedAccount,
   isAddingConnectedAccountRef,
+  isBrowserConnectorHandoffRef,
   isConnectIntentWaitingForAppKit,
   isInitialized,
   isSigningOutAll,
@@ -390,7 +392,7 @@ export function useSeizeConnectProviderEffects({
     }
 
     debounceTimeoutRef.current = setTimeout(() => {
-      if (isSigningOutAllRef.current) {
+      if (isSigningOutAllRef.current || isBrowserConnectorHandoffRef.current) {
         return;
       }
       syncWalletConnectionState({
@@ -423,6 +425,7 @@ export function useSeizeConnectProviderEffects({
     isInitialized,
     isSigningOutAll,
     isSigningOutAllRef,
+    isBrowserConnectorHandoffRef,
     storedConnectedAccounts,
     walletState,
     setConnected,

--- a/renderer/components/auth/seizeConnectEffects.ts
+++ b/renderer/components/auth/seizeConnectEffects.ts
@@ -19,6 +19,7 @@ import {
   ADD_FLOW_CANCEL_GRACE_MS,
   normalizeAddress,
 } from "./seizeConnectWalletState";
+import { shouldReconcileConnectorState } from "./connector-selection-lifecycle";
 
 interface SeizeConnectProviderEffectsParams {
   readonly account: {
@@ -392,7 +393,13 @@ export function useSeizeConnectProviderEffects({
     }
 
     debounceTimeoutRef.current = setTimeout(() => {
-      if (isSigningOutAllRef.current || isBrowserConnectorHandoffRef.current) {
+      if (
+        !shouldReconcileConnectorState({
+          isSigningOutAll: isSigningOutAllRef.current,
+          isBrowserConnectorHandoff: isBrowserConnectorHandoffRef.current,
+          isConnectorChooserOpen: stateOpen,
+        })
+      ) {
         return;
       }
       syncWalletConnectionState({
@@ -426,6 +433,7 @@ export function useSeizeConnectProviderEffects({
     isSigningOutAll,
     isSigningOutAllRef,
     isBrowserConnectorHandoffRef,
+    stateOpen,
     storedConnectedAccounts,
     walletState,
     setConnected,

--- a/renderer/components/auth/seizeConnectTypes.ts
+++ b/renderer/components/auth/seizeConnectTypes.ts
@@ -54,6 +54,12 @@ export interface SeizeConnectContextType {
    */
   seizeAcceptConnection: (address: string) => void;
 
+  /** Prevents temporary connector fallback from changing the active profile. */
+  seizeBeginBrowserConnectorHandoff: () => void;
+
+  /** Ends Browser handoff and restores the explicitly selected profile. */
+  seizeEndBrowserConnectorHandoff: () => void;
+
   /** Whether the connection modal is currently open */
   seizeConnectOpen: boolean;
 

--- a/renderer/components/browser-connector/BrowserConnectorConnect.tsx
+++ b/renderer/components/browser-connector/BrowserConnectorConnect.tsx
@@ -21,6 +21,7 @@ import {
   getSessionNonce,
   type RefreshTokenSessionClientType,
 } from "@/services/auth/session-v2.utils";
+import Button from "@/components/utils/button/Button";
 import authModalStyles from "../auth/Auth.module.css";
 import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
 import HeaderUserConnect from "../header/user/HeaderUserConnect";
@@ -696,21 +697,25 @@ export default function BrowserConnectorConnect(
               )}
             </div>
             <div className={authModalStyles["signModalFooter"]}>
-              <button
+              <Button
                 type="button"
                 onClick={() => void handleAuthModalCancel()}
-                className={authModalStyles["signModalCancelButton"]}
+                variant="secondary"
+                size="md"
+                className="tw-min-w-32 max-[576px]:tw-min-w-0 max-[576px]:tw-flex-1"
               >
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
                 disabled={isAuthenticating}
                 onClick={() => void handleAuthModalSign()}
-                className={authModalStyles["signModalConfirmButton"]}
+                variant="action"
+                size="md"
+                className="tw-min-w-32 max-[576px]:tw-min-w-0 max-[576px]:tw-flex-1"
               >
                 {isAuthenticating ? "Confirm in your wallet" : "Sign"}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/renderer/components/header/user/HeaderUserConnectModal.tsx
+++ b/renderer/components/header/user/HeaderUserConnectModal.tsx
@@ -20,7 +20,10 @@ import {
   CONNECTOR_MODAL_BODY_CLASS,
   CONNECTOR_MODAL_DIALOG_CLASS,
 } from "./connector-modal-layout";
-import { completeConnectorSelection } from "./complete-connector-selection";
+import {
+  completeConnectorSelection,
+  ConnectorSelectionGuard,
+} from "./complete-connector-selection";
 import { getSeedWalletSelectionState } from "./seed-wallet-selection-state";
 
 const CONNECTOR_MODAL_LOCALE = DEFAULT_LOCALE;
@@ -40,6 +43,9 @@ export default function HeaderUserConnectModal({
 
   const isBrowser = !isElectron();
   const [openSection, setOpenSection] = useState<string | null>(null);
+  const [connectorSelectionGuard] = useState(
+    () => new ConnectorSelectionGuard()
+  );
 
   useEffect(() => {
     if (!show) setOpenSection(null);
@@ -97,6 +103,7 @@ export default function HeaderUserConnectModal({
             <ConnectorList
               connectors={otherConnectors}
               selected={handleConnectorSelected}
+              selectionGuard={connectorSelectionGuard}
               className="tw-mb-3"
             />
           ) : (
@@ -109,6 +116,7 @@ export default function HeaderUserConnectModal({
                 <ConnectorList
                   connectors={seedConnectors}
                   selected={handleConnectorSelected}
+                  selectionGuard={connectorSelectionGuard}
                 />
                 {seedConnectors.length === 0 && (
                   <div className="tw-text-center">
@@ -141,6 +149,7 @@ export default function HeaderUserConnectModal({
                 <ConnectorList
                   connectors={browserConnectors}
                   selected={handleConnectorSelected}
+                  selectionGuard={connectorSelectionGuard}
                 />
               </ConnectSection>
               <ConnectSection
@@ -152,6 +161,7 @@ export default function HeaderUserConnectModal({
                 <ConnectorList
                   connectors={otherConnectors}
                   selected={handleConnectorSelected}
+                  selectionGuard={connectorSelectionGuard}
                 />
               </ConnectSection>
             </>
@@ -170,10 +180,12 @@ export default function HeaderUserConnectModal({
 function ConnectorList({
   connectors,
   selected,
+  selectionGuard,
   className = "",
 }: Readonly<{
   connectors: Connector[];
   selected: (connector: Connector) => void;
+  selectionGuard: ConnectorSelectionGuard;
   className?: string;
 }>) {
   return (
@@ -185,6 +197,7 @@ function ConnectorList({
           key={connector.id}
           connector={connector}
           selected={selected}
+          selectionGuard={selectionGuard}
         />
       ))}
     </div>
@@ -223,6 +236,7 @@ function ConnectorSelector(
   props: Readonly<{
     connector: Connector;
     selected: (connector: Connector) => void;
+    selectionGuard: ConnectorSelectionGuard;
   }>
 ) {
   const { connectAsync } = useConnect();
@@ -258,36 +272,44 @@ function ConnectorSelector(
       return;
     }
 
-    if (isConnected) {
-      try {
-        seizeSwitchConnectedAccount(props.connector.id);
-      } catch (connectionError) {
-        reportConnectionError(connectionError);
-        return;
-      }
-      props.selected(props.connector);
-      return;
-    }
-
-    if (props.connector.type === "walletConnect") {
-      void Promise.resolve(
-        open({ view: "ConnectingWalletConnectBasic" })
-      ).catch(reportConnectionError);
-      props.selected(props.connector);
+    if (!props.selectionGuard.tryAcquire()) {
       return;
     }
 
     try {
-      await completeConnectorSelection({
-        connect: async () => {
-          await connectAsync({ connector: props.connector });
-        },
-        seedWalletAddress: isSeed ? props.connector.id : null,
-        acceptConnection: seizeAcceptConnection,
-        select: () => props.selected(props.connector),
-      });
-    } catch (connectionError) {
-      reportConnectionError(connectionError);
+      if (isConnected) {
+        try {
+          seizeSwitchConnectedAccount(props.connector.id);
+        } catch (connectionError) {
+          reportConnectionError(connectionError);
+          return;
+        }
+        props.selected(props.connector);
+        return;
+      }
+
+      if (props.connector.type === "walletConnect") {
+        void Promise.resolve(
+          open({ view: "ConnectingWalletConnectBasic" })
+        ).catch(reportConnectionError);
+        props.selected(props.connector);
+        return;
+      }
+
+      try {
+        await completeConnectorSelection({
+          connect: async () => {
+            await connectAsync({ connector: props.connector });
+          },
+          seedWalletAddress: isSeed ? props.connector.id : null,
+          acceptConnection: seizeAcceptConnection,
+          select: () => props.selected(props.connector),
+        });
+      } catch (connectionError) {
+        reportConnectionError(connectionError);
+      }
+    } finally {
+      props.selectionGuard.release();
     }
   };
 

--- a/renderer/components/header/user/HeaderUserConnectModal.tsx
+++ b/renderer/components/header/user/HeaderUserConnectModal.tsx
@@ -251,7 +251,7 @@ function ConnectorSelector(
     console.error("error", connectionError);
   };
 
-  const onConnect = () => {
+  const onConnect = async (): Promise<void> => {
     if (isActive) {
       return;
     }
@@ -271,12 +271,16 @@ function ConnectorSelector(
       void Promise.resolve(
         open({ view: "ConnectingWalletConnectBasic" })
       ).catch(reportConnectionError);
-    } else {
-      void connectAsync({ connector: props.connector }).catch(
-        reportConnectionError
-      );
+      props.selected(props.connector);
+      return;
     }
-    props.selected(props.connector);
+
+    try {
+      await connectAsync({ connector: props.connector });
+      props.selected(props.connector);
+    } catch (connectionError) {
+      reportConnectionError(connectionError);
+    }
   };
 
   const ariaLabel = isActive
@@ -292,7 +296,7 @@ function ConnectorSelector(
   return (
     <button
       type="button"
-      onClick={onConnect}
+      onClick={() => void onConnect()}
       disabled={isActive}
       aria-label={ariaLabel}
       className={`tw-flex tw-w-full tw-items-center tw-justify-start tw-gap-3 tw-rounded-lg tw-border tw-border-solid tw-py-3 tw-pl-3 tw-pr-3 tw-text-left tw-text-iron-100 tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 disabled:tw-cursor-default disabled:tw-opacity-100 ${

--- a/renderer/components/header/user/HeaderUserConnectModal.tsx
+++ b/renderer/components/header/user/HeaderUserConnectModal.tsx
@@ -20,6 +20,7 @@ import {
   CONNECTOR_MODAL_BODY_CLASS,
   CONNECTOR_MODAL_DIALOG_CLASS,
 } from "./connector-modal-layout";
+import { completeConnectorSelection } from "./complete-connector-selection";
 import { getSeedWalletSelectionState } from "./seed-wallet-selection-state";
 
 const CONNECTOR_MODAL_LOCALE = DEFAULT_LOCALE;
@@ -229,6 +230,7 @@ function ConnectorSelector(
   const {
     address: activeAddress,
     connectedAccounts,
+    seizeAcceptConnection,
     seizeSwitchConnectedAccount,
   } = useSeizeConnectContext();
 
@@ -276,8 +278,14 @@ function ConnectorSelector(
     }
 
     try {
-      await connectAsync({ connector: props.connector });
-      props.selected(props.connector);
+      await completeConnectorSelection({
+        connect: async () => {
+          await connectAsync({ connector: props.connector });
+        },
+        seedWalletAddress: isSeed ? props.connector.id : null,
+        acceptConnection: seizeAcceptConnection,
+        select: () => props.selected(props.connector),
+      });
     } catch (connectionError) {
       reportConnectionError(connectionError);
     }

--- a/renderer/components/header/user/HeaderUserConnectModal.tsx
+++ b/renderer/components/header/user/HeaderUserConnectModal.tsx
@@ -15,7 +15,13 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Connector, useConnect, useConnectors } from "wagmi";
+import {
+  type Connector,
+  useConnect,
+  useConnections,
+  useConnectors,
+  useDisconnect,
+} from "wagmi";
 import {
   CONNECTOR_MODAL_BODY_CLASS,
   CONNECTOR_MODAL_DIALOG_CLASS,
@@ -23,6 +29,7 @@ import {
 import {
   completeConnectorSelection,
   ConnectorSelectionGuard,
+  startFreshBrowserConnectorSelection,
 } from "./complete-connector-selection";
 import { getSeedWalletSelectionState } from "./seed-wallet-selection-state";
 
@@ -240,6 +247,8 @@ function ConnectorSelector(
   }>
 ) {
   const { connectAsync } = useConnect();
+  const connections = useConnections();
+  const { disconnectAsync } = useDisconnect();
   const { open } = useAppKit();
   const {
     address: activeAddress,
@@ -293,6 +302,30 @@ function ConnectorSelector(
           open({ view: "ConnectingWalletConnectBasic" })
         ).catch(reportConnectionError);
         props.selected(props.connector);
+        return;
+      }
+
+      if (props.connector.type === "browser") {
+        try {
+          await startFreshBrowserConnectorSelection({
+            select: () => props.selected(props.connector),
+            reset: async () => {
+              const trackedConnection = connections.some(
+                (connection) => connection.connector.uid === props.connector.uid
+              );
+              if (trackedConnection) {
+                await disconnectAsync({ connector: props.connector });
+                return;
+              }
+              await props.connector.disconnect();
+            },
+            connect: async () => {
+              await connectAsync({ connector: props.connector });
+            },
+          });
+        } catch (connectionError) {
+          reportConnectionError(connectionError);
+        }
         return;
       }
 

--- a/renderer/components/header/user/HeaderUserConnectModal.tsx
+++ b/renderer/components/header/user/HeaderUserConnectModal.tsx
@@ -254,6 +254,8 @@ function ConnectorSelector(
     address: activeAddress,
     connectedAccounts,
     seizeAcceptConnection,
+    seizeBeginBrowserConnectorHandoff,
+    seizeEndBrowserConnectorHandoff,
     seizeSwitchConnectedAccount,
   } = useSeizeConnectContext();
 
@@ -308,6 +310,7 @@ function ConnectorSelector(
       if (props.connector.type === "browser") {
         try {
           await startFreshBrowserConnectorSelection({
+            beginHandoff: () => seizeBeginBrowserConnectorHandoff(),
             select: () => props.selected(props.connector),
             reset: async () => {
               const trackedConnection = connections.some(
@@ -322,6 +325,7 @@ function ConnectorSelector(
             connect: async () => {
               await connectAsync({ connector: props.connector });
             },
+            endHandoff: () => seizeEndBrowserConnectorHandoff(),
           });
         } catch (connectionError) {
           reportConnectionError(connectionError);

--- a/renderer/components/header/user/complete-connector-selection.ts
+++ b/renderer/components/header/user/complete-connector-selection.ts
@@ -5,6 +5,23 @@ interface CompleteConnectorSelectionParams {
   readonly select: () => void;
 }
 
+/** Serializes connector choices shared by every row in one chooser. */
+export class ConnectorSelectionGuard {
+  private active = false;
+
+  tryAcquire(): boolean {
+    if (this.active) {
+      return false;
+    }
+    this.active = true;
+    return true;
+  }
+
+  release(): void {
+    this.active = false;
+  }
+}
+
 /**
  * Makes a newly selected Core wallet authoritative before the chooser closes.
  * This prevents the previous active Core connector from being restored while

--- a/renderer/components/header/user/complete-connector-selection.ts
+++ b/renderer/components/header/user/complete-connector-selection.ts
@@ -6,7 +6,9 @@ interface CompleteConnectorSelectionParams {
 }
 
 interface StartFreshBrowserConnectorSelectionParams {
+  readonly beginHandoff: () => void;
   readonly connect: () => Promise<void>;
+  readonly endHandoff: () => void;
   readonly reset: () => Promise<void>;
   readonly select: () => void;
 }
@@ -53,11 +55,18 @@ export async function completeConnectorSelection({
  * browser, and it must reset any previous connector session before reconnecting.
  */
 export async function startFreshBrowserConnectorSelection({
+  beginHandoff,
   connect,
+  endHandoff,
   reset,
   select,
 }: StartFreshBrowserConnectorSelectionParams): Promise<void> {
+  beginHandoff();
   select();
-  await reset();
-  await connect();
+  try {
+    await reset();
+    await connect();
+  } finally {
+    endHandoff();
+  }
 }

--- a/renderer/components/header/user/complete-connector-selection.ts
+++ b/renderer/components/header/user/complete-connector-selection.ts
@@ -5,6 +5,12 @@ interface CompleteConnectorSelectionParams {
   readonly select: () => void;
 }
 
+interface StartFreshBrowserConnectorSelectionParams {
+  readonly connect: () => Promise<void>;
+  readonly reset: () => Promise<void>;
+  readonly select: () => void;
+}
+
 /** Serializes connector choices shared by every row in one chooser. */
 export class ConnectorSelectionGuard {
   private active = false;
@@ -40,4 +46,18 @@ export async function completeConnectorSelection({
   }
 
   select();
+}
+
+/**
+ * Browser handoff must close the chooser before waiting for the external
+ * browser, and it must reset any previous connector session before reconnecting.
+ */
+export async function startFreshBrowserConnectorSelection({
+  connect,
+  reset,
+  select,
+}: StartFreshBrowserConnectorSelectionParams): Promise<void> {
+  select();
+  await reset();
+  await connect();
 }

--- a/renderer/components/header/user/complete-connector-selection.ts
+++ b/renderer/components/header/user/complete-connector-selection.ts
@@ -1,0 +1,26 @@
+interface CompleteConnectorSelectionParams {
+  readonly acceptConnection: (address: string) => void;
+  readonly connect: () => Promise<void>;
+  readonly seedWalletAddress: string | null;
+  readonly select: () => void;
+}
+
+/**
+ * Makes a newly selected Core wallet authoritative before the chooser closes.
+ * This prevents the previous active Core connector from being restored while
+ * the provider's debounced account reconciliation is still pending.
+ */
+export async function completeConnectorSelection({
+  acceptConnection,
+  connect,
+  seedWalletAddress,
+  select,
+}: CompleteConnectorSelectionParams): Promise<void> {
+  await connect();
+
+  if (seedWalletAddress) {
+    acceptConnection(seedWalletAddress);
+  }
+
+  select();
+}

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1371,27 +1371,39 @@ const connectorSelectorFunction = findFunction(
   connectorModal,
   "ConnectorSelector",
 );
-const connectorOnConnect = connectorSelectorFunction
-  ? findVariable(connectorSelectorFunction, "onConnect")
-  : undefined;
-const awaitedConnectorSelection = connectorOnConnect
+const connectorSelectionPath =
+  "renderer/components/header/user/complete-connector-selection.ts";
+const connectorSelection = parseSource(connectorSelectionPath);
+const completeConnectorSelectionFunction = findFunction(
+  connectorSelection,
+  "completeConnectorSelection",
+);
+const awaitedConnect = completeConnectorSelectionFunction
   ? findDescendant(
-      connectorOnConnect,
+      completeConnectorSelectionFunction,
       (node) =>
-        ts.isTryStatement(node) &&
-        Boolean(
-          findDescendant(
-            node.tryBlock,
-            (child) =>
-              ts.isAwaitExpression(child) &&
-              callsIdentifier(child.expression, "connectAsync"),
-          ),
-        ) &&
-        Boolean(
-          findDescendant(node.tryBlock, (child) =>
-            isPropertyCall(child, "props", "selected"),
-          ),
-        ),
+        ts.isAwaitExpression(node) &&
+        ts.isCallExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === "connect",
+    )
+  : undefined;
+const acceptedConnection = completeConnectorSelectionFunction
+  ? findDescendant(
+      completeConnectorSelectionFunction,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "acceptConnection",
+    )
+  : undefined;
+const completedSelection = completeConnectorSelectionFunction
+  ? findDescendant(
+      completeConnectorSelectionFunction,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "select",
     )
   : undefined;
 assertContract(
@@ -1415,7 +1427,7 @@ assertContract(
     connectorSelectorFunction &&
     callsIdentifier(connectorSelectorFunction, "getSeedWalletSelectionState") &&
     callsIdentifier(connectorSelectorFunction, "seizeSwitchConnectedAccount") &&
-    Boolean(awaitedConnectorSelection) &&
+    callsIdentifier(connectorSelectorFunction, "completeConnectorSelection") &&
     jsxAttributeUsesIdentifier(
       connectorSelectorFunction,
       "button",
@@ -1423,7 +1435,16 @@ assertContract(
       "isActive",
     ),
   connectorModalPath,
-  "Core wallet chooser must await new connections before closing, stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
+  "Core wallet chooser must complete new connections before closing, stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
+);
+assertContract(
+  awaitedConnect &&
+    acceptedConnection &&
+    completedSelection &&
+    awaitedConnect.getStart() < acceptedConnection.getStart() &&
+    acceptedConnection.getStart() < completedSelection.getStart(),
+  connectorSelectionPath,
+  "Core wallet selection must connect, make the selected address authoritative, and only then close the chooser",
 );
 
 const browserConnectorConnectPath =

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1404,6 +1404,82 @@ const electronAddOriginGuard = electronAddDirectOpenGuard
         node.right.text === "addFlowOriginWallet",
     )
   : undefined;
+const browserConnectorHandoffRef = findVariable(
+  connectProvider,
+  "isBrowserConnectorHandoffRef",
+);
+const beginBrowserConnectorHandoff = findVariable(
+  connectProvider,
+  "seizeBeginBrowserConnectorHandoff",
+);
+const endBrowserConnectorHandoff = findVariable(
+  connectProvider,
+  "seizeEndBrowserConnectorHandoff",
+);
+const beginBrowserHandoffStateGuard = beginBrowserConnectorHandoff
+  ? findDescendant(
+      beginBrowserConnectorHandoff,
+      (node) =>
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isMemberExpression(
+          node.left,
+          "isBrowserConnectorHandoffRef",
+          "current",
+        ) &&
+        node.right.kind === ts.SyntaxKind.TrueKeyword,
+    )
+  : undefined;
+const beginBrowserHandoffCancelsAdd = beginBrowserConnectorHandoff
+  ? callsIdentifier(
+      beginBrowserConnectorHandoff,
+      "setIsAddingConnectedAccount",
+    ) &&
+    Boolean(
+      findDescendant(
+        beginBrowserConnectorHandoff,
+        (node) =>
+          ts.isBinaryExpression(node) &&
+          node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+          isMemberExpression(
+            node.left,
+            "isAddingConnectedAccountRef",
+            "current",
+          ) &&
+          node.right.kind === ts.SyntaxKind.FalseKeyword,
+      ),
+    )
+  : false;
+const endBrowserHandoffStateGuard = endBrowserConnectorHandoff
+  ? findDescendant(
+      endBrowserConnectorHandoff,
+      (node) =>
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isMemberExpression(
+          node.left,
+          "isBrowserConnectorHandoffRef",
+          "current",
+        ) &&
+        node.right.kind === ts.SyntaxKind.FalseKeyword,
+    )
+  : undefined;
+const providerEffectsCall = findDescendant(
+  connectProvider,
+  (node) =>
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "useSeizeConnectProviderEffects",
+);
+const providerEffectsReceivesBrowserHandoffRef = providerEffectsCall
+  ? Boolean(
+      findDescendant(
+        providerEffectsCall,
+        (node) =>
+          ts.isIdentifier(node) && node.text === "isBrowserConnectorHandoffRef",
+      ),
+    )
+  : false;
 const localConnectorDirectOpenGuard = seizeAddConnectedAccount
   ? findDescendant(
       seizeAddConnectedAccount,
@@ -1473,6 +1549,17 @@ assertContract(
   "Electron Add must preserve the origin, set the add-flow guard true, open the chooser, and not disconnect or activate a wallet",
 );
 assertContract(
+  browserConnectorHandoffRef &&
+    beginBrowserHandoffStateGuard &&
+    beginBrowserHandoffCancelsAdd &&
+    endBrowserHandoffStateGuard &&
+    endBrowserConnectorHandoff &&
+    callsIdentifier(endBrowserConnectorHandoff, "restoreStoredWalletState") &&
+    providerEffectsReceivesBrowserHandoffRef,
+  "renderer/components/auth/SeizeConnectProvider.tsx",
+  "Browser reconnect handoff must suppress generic Add reconciliation and restore the explicitly selected profile",
+);
+assertContract(
   electronChooserDirectOpenGuard &&
     appKitReadinessWait &&
     electronChooserDirectOpenGuard.getStart() < appKitReadinessWait.getStart(),
@@ -1537,6 +1624,14 @@ const browserConnectorSelectionGuard = connectorOnConnect
         ) &&
         callsIdentifier(node.thenStatement, "disconnectAsync") &&
         callsIdentifier(node.thenStatement, "connectAsync") &&
+        callsIdentifier(
+          node.thenStatement,
+          "seizeBeginBrowserConnectorHandoff",
+        ) &&
+        callsIdentifier(
+          node.thenStatement,
+          "seizeEndBrowserConnectorHandoff",
+        ) &&
         Boolean(
           findDescendant(
             node.thenStatement,
@@ -1600,6 +1695,15 @@ const browserSelectionClosed = startFreshBrowserConnectorSelectionFunction
         node.expression.text === "select",
     )
   : undefined;
+const browserHandoffBegan = startFreshBrowserConnectorSelectionFunction
+  ? findDescendant(
+      startFreshBrowserConnectorSelectionFunction,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "beginHandoff",
+    )
+  : undefined;
 const browserConnectorReset = startFreshBrowserConnectorSelectionFunction
   ? findDescendant(
       startFreshBrowserConnectorSelectionFunction,
@@ -1618,6 +1722,19 @@ const browserConnectorConnected = startFreshBrowserConnectorSelectionFunction
         ts.isCallExpression(node.expression) &&
         ts.isIdentifier(node.expression.expression) &&
         node.expression.expression.text === "connect",
+    )
+  : undefined;
+const browserHandoffEnded = startFreshBrowserConnectorSelectionFunction
+  ? findDescendant(
+      startFreshBrowserConnectorSelectionFunction,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "endHandoff" &&
+        ts.isExpressionStatement(node.parent) &&
+        ts.isBlock(node.parent.parent) &&
+        ts.isTryStatement(node.parent.parent.parent) &&
+        node.parent.parent.parent.finallyBlock === node.parent.parent,
     )
   : undefined;
 assertContract(
@@ -1664,13 +1781,46 @@ assertContract(
 );
 assertContract(
   browserConnectorSelectionGuard &&
+    browserHandoffBegan &&
     browserSelectionClosed &&
     browserConnectorReset &&
     browserConnectorConnected &&
+    browserHandoffEnded &&
+    browserHandoffBegan.getStart() < browserSelectionClosed.getStart() &&
     browserSelectionClosed.getStart() < browserConnectorReset.getStart() &&
-    browserConnectorReset.getStart() < browserConnectorConnected.getStart(),
+    browserConnectorReset.getStart() < browserConnectorConnected.getStart() &&
+    browserConnectorConnected.getStart() < browserHandoffEnded.getStart(),
   connectorSelectionPath,
-  "Browser selection must close the chooser immediately, reset the previous connector session, and only then reconnect",
+  "Browser selection must protect the active profile, close immediately, reset and reconnect, then always end the handoff",
+);
+
+const connectEffectsPath = "renderer/components/auth/seizeConnectEffects.ts";
+const connectEffects = parseSource(connectEffectsPath);
+const useConnectEffectsFunction = findFunction(
+  connectEffects,
+  "useSeizeConnectProviderEffects",
+);
+const browserHandoffEffectGuard = useConnectEffectsFunction
+  ? findDescendant(
+      useConnectEffectsFunction,
+      (node) =>
+        ts.isIfStatement(node) &&
+        referencesMember(
+          node.expression,
+          "isBrowserConnectorHandoffRef",
+          "current",
+        ) &&
+        Boolean(
+          findDescendant(node.thenStatement, (child) =>
+            ts.isReturnStatement(child),
+          ),
+        ),
+    )
+  : undefined;
+assertContract(
+  Boolean(browserHandoffEffectGuard),
+  connectEffectsPath,
+  "Wallet reconciliation must ignore temporary Wagmi fallback connectors during Browser reconnect handoff",
 );
 
 const browserConnectorConnectPath =

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -114,6 +114,86 @@ function hasJsxElement(node, elementName) {
   );
 }
 
+function countJsxElements(node, elementName) {
+  let count = 0;
+  const visit = (candidate) => {
+    if (
+      (ts.isJsxOpeningElement(candidate) ||
+        ts.isJsxSelfClosingElement(candidate)) &&
+      ts.isIdentifier(candidate.tagName) &&
+      candidate.tagName.text === elementName
+    ) {
+      count += 1;
+    }
+    ts.forEachChild(candidate, visit);
+  };
+  visit(node);
+  return count;
+}
+
+function isMemberExpression(node, objectName, memberName) {
+  const expression = unwrapExpression(node);
+  if (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression)
+  ) {
+    return (
+      expression.expression.text === objectName &&
+      expression.name.text === memberName
+    );
+  }
+  return Boolean(
+    ts.isElementAccessExpression(expression) &&
+      ts.isIdentifier(expression.expression) &&
+      expression.expression.text === objectName &&
+      expression.argumentExpression &&
+      ts.isStringLiteral(expression.argumentExpression) &&
+      expression.argumentExpression.text === memberName,
+  );
+}
+
+function findJsxElementByMemberAttribute(
+  node,
+  elementName,
+  attributeName,
+  objectName,
+  memberName,
+) {
+  return findDescendant(node, (candidate) => {
+    if (
+      !ts.isJsxElement(candidate) ||
+      !ts.isIdentifier(candidate.openingElement.tagName) ||
+      candidate.openingElement.tagName.text !== elementName
+    ) {
+      return false;
+    }
+    const attribute = candidate.openingElement.attributes.properties.find(
+      (property) =>
+        ts.isJsxAttribute(property) && property.name.text === attributeName,
+    );
+    return Boolean(
+      attribute &&
+        ts.isJsxAttribute(attribute) &&
+        attribute.initializer &&
+        ts.isJsxExpression(attribute.initializer) &&
+        attribute.initializer.expression &&
+        isMemberExpression(
+          attribute.initializer.expression,
+          objectName,
+          memberName,
+        ),
+    );
+  });
+}
+
+function referencesMember(node, objectName, memberName) {
+  return Boolean(
+    findDescendant(node, (candidate) =>
+      isMemberExpression(candidate, objectName, memberName),
+    ),
+  );
+}
+
 function hasJsxElementWithinMemberElement(
   node,
   objectName,
@@ -1371,6 +1451,35 @@ const connectorSelectorFunction = findFunction(
   connectorModal,
   "ConnectorSelector",
 );
+const connectorOnConnect = connectorSelectorFunction
+  ? findVariable(connectorSelectorFunction, "onConnect")
+  : undefined;
+const isSelectionGuardCall = (node, methodName) =>
+  ts.isCallExpression(node) &&
+  ts.isPropertyAccessExpression(node.expression) &&
+  node.expression.name.text === methodName &&
+  ts.isPropertyAccessExpression(node.expression.expression) &&
+  ts.isIdentifier(node.expression.expression.expression) &&
+  node.expression.expression.expression.text === "props" &&
+  node.expression.expression.name.text === "selectionGuard";
+const selectionGuardAcquire = connectorOnConnect
+  ? findDescendant(connectorOnConnect, (node) =>
+      isSelectionGuardCall(node, "tryAcquire"),
+    )
+  : undefined;
+const selectionGuardRelease = connectorOnConnect
+  ? findDescendant(
+      connectorOnConnect,
+      (node) =>
+        ts.isTryStatement(node) &&
+        node.finallyBlock &&
+        Boolean(
+          findDescendant(node.finallyBlock, (child) =>
+            isSelectionGuardCall(child, "release"),
+          ),
+        ),
+    )
+  : undefined;
 const connectorSelectionPath =
   "renderer/components/header/user/complete-connector-selection.ts";
 const connectorSelection = parseSource(connectorSelectionPath);
@@ -1428,6 +1537,8 @@ assertContract(
     callsIdentifier(connectorSelectorFunction, "getSeedWalletSelectionState") &&
     callsIdentifier(connectorSelectorFunction, "seizeSwitchConnectedAccount") &&
     callsIdentifier(connectorSelectorFunction, "completeConnectorSelection") &&
+    Boolean(selectionGuardAcquire) &&
+    Boolean(selectionGuardRelease) &&
     jsxAttributeUsesIdentifier(
       connectorSelectorFunction,
       "button",
@@ -1435,7 +1546,7 @@ assertContract(
       "isActive",
     ),
   connectorModalPath,
-  "Core wallet chooser must complete new connections before closing, stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
+  "Core wallet chooser must serialize selections, complete new connections before closing, stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
 );
 assertContract(
   awaitedConnect &&
@@ -1454,19 +1565,28 @@ const browserConnectorConnectFunction = findFunction(
   browserConnectorConnect,
   "BrowserConnectorConnect",
 );
+const browserConnectorAuthFooter = browserConnectorConnectFunction
+  ? findJsxElementByMemberAttribute(
+      browserConnectorConnectFunction,
+      "div",
+      "className",
+      "authModalStyles",
+      "signModalFooter",
+    )
+  : undefined;
 assertContract(
   browserConnectorConnectFunction &&
-    hasJsxElement(browserConnectorConnectFunction, "Button") &&
-    !findDescendant(
-      browserConnectorConnectFunction,
-      (node) =>
-        ts.isStringLiteral(node) &&
-        ["signModalCancelButton", "signModalConfirmButton"].includes(
-          node.text,
-        ),
+    browserConnectorAuthFooter &&
+    countJsxElements(browserConnectorAuthFooter, "Button") === 2 &&
+    !["signModalCancelButton", "signModalConfirmButton"].some((memberName) =>
+      referencesMember(
+        browserConnectorConnectFunction,
+        "authModalStyles",
+        memberName,
+      ),
     ),
   browserConnectorConnectPath,
-  "browser-connector authentication actions must use shared styled buttons instead of removed CSS-module classes",
+  "browser-connector authentication footer must contain both shared styled buttons and must not use removed CSS-module classes",
 );
 
 const seizeConnectModalContextPath =

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1357,6 +1357,7 @@ const electronAddDirectOpenGuard = seizeAddConnectedAccount
         callsIdentifier(node.expression, "isElectron") &&
         callsIdentifier(node.thenStatement, "openAddConnectedAccountModal") &&
         callsIdentifier(node.thenStatement, "getWalletAddress") &&
+        callsIdentifier(node.thenStatement, "setIsAddingConnectedAccount") &&
         !callsIdentifier(node.thenStatement, "disconnect") &&
         !callsIdentifier(node.thenStatement, "setActiveWalletAccount") &&
         !callsIdentifier(node.thenStatement, "setConnected") &&
@@ -1365,6 +1366,42 @@ const electronAddDirectOpenGuard = seizeAddConnectedAccount
             ts.isReturnStatement(child),
           ),
         ),
+    )
+  : undefined;
+const electronAddStateGuard = electronAddDirectOpenGuard
+  ? findDescendant(
+      electronAddDirectOpenGuard.thenStatement,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "setIsAddingConnectedAccount" &&
+        node.arguments.length === 1 &&
+        node.arguments[0].kind === ts.SyntaxKind.TrueKeyword,
+    )
+  : undefined;
+const electronAddRefGuard = electronAddDirectOpenGuard
+  ? findDescendant(
+      electronAddDirectOpenGuard.thenStatement,
+      (node) =>
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isMemberExpression(
+          node.left,
+          "isAddingConnectedAccountRef",
+          "current",
+        ) &&
+        node.right.kind === ts.SyntaxKind.TrueKeyword,
+    )
+  : undefined;
+const electronAddOriginGuard = electronAddDirectOpenGuard
+  ? findDescendant(
+      electronAddDirectOpenGuard.thenStatement,
+      (node) =>
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        isMemberExpression(node.left, "addFlowOriginAddressRef", "current") &&
+        ts.isIdentifier(node.right) &&
+        node.right.text === "addFlowOriginWallet",
     )
   : undefined;
 const localConnectorDirectOpenGuard = seizeAddConnectedAccount
@@ -1428,9 +1465,12 @@ assertContract(
   "live wallet selection must preserve the explicitly active browser connector over stale Wagmi state",
 );
 assertContract(
-  Boolean(electronAddDirectOpenGuard),
+  electronAddDirectOpenGuard &&
+    electronAddStateGuard &&
+    electronAddRefGuard &&
+    electronAddOriginGuard,
   "renderer/components/auth/SeizeConnectProvider.tsx",
-  "Electron Add must only open the chooser and must not disconnect or activate a wallet",
+  "Electron Add must preserve the origin, set the add-flow guard true, open the chooser, and not disconnect or activate a wallet",
 );
 assertContract(
   electronChooserDirectOpenGuard &&
@@ -1480,12 +1520,48 @@ const selectionGuardRelease = connectorOnConnect
         ),
     )
   : undefined;
+const browserConnectorSelectionGuard = connectorOnConnect
+  ? findDescendant(
+      connectorOnConnect,
+      (node) =>
+        ts.isIfStatement(node) &&
+        Boolean(
+          findDescendant(
+            node.expression,
+            (child) => ts.isStringLiteral(child) && child.text === "browser",
+          ),
+        ) &&
+        callsIdentifier(
+          node.thenStatement,
+          "startFreshBrowserConnectorSelection",
+        ) &&
+        callsIdentifier(node.thenStatement, "disconnectAsync") &&
+        callsIdentifier(node.thenStatement, "connectAsync") &&
+        Boolean(
+          findDescendant(
+            node.thenStatement,
+            (child) =>
+              ts.isCallExpression(child) &&
+              ts.isPropertyAccessExpression(child.expression) &&
+              child.expression.name.text === "disconnect" &&
+              ts.isPropertyAccessExpression(child.expression.expression) &&
+              ts.isIdentifier(child.expression.expression.expression) &&
+              child.expression.expression.expression.text === "props" &&
+              child.expression.expression.name.text === "connector",
+          ),
+        ),
+    )
+  : undefined;
 const connectorSelectionPath =
   "renderer/components/header/user/complete-connector-selection.ts";
 const connectorSelection = parseSource(connectorSelectionPath);
 const completeConnectorSelectionFunction = findFunction(
   connectorSelection,
   "completeConnectorSelection",
+);
+const startFreshBrowserConnectorSelectionFunction = findFunction(
+  connectorSelection,
+  "startFreshBrowserConnectorSelection",
 );
 const awaitedConnect = completeConnectorSelectionFunction
   ? findDescendant(
@@ -1513,6 +1589,35 @@ const completedSelection = completeConnectorSelectionFunction
         ts.isCallExpression(node) &&
         ts.isIdentifier(node.expression) &&
         node.expression.text === "select",
+    )
+  : undefined;
+const browserSelectionClosed = startFreshBrowserConnectorSelectionFunction
+  ? findDescendant(
+      startFreshBrowserConnectorSelectionFunction,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "select",
+    )
+  : undefined;
+const browserConnectorReset = startFreshBrowserConnectorSelectionFunction
+  ? findDescendant(
+      startFreshBrowserConnectorSelectionFunction,
+      (node) =>
+        ts.isAwaitExpression(node) &&
+        ts.isCallExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === "reset",
+    )
+  : undefined;
+const browserConnectorConnected = startFreshBrowserConnectorSelectionFunction
+  ? findDescendant(
+      startFreshBrowserConnectorSelectionFunction,
+      (node) =>
+        ts.isAwaitExpression(node) &&
+        ts.isCallExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === "connect",
     )
   : undefined;
 assertContract(
@@ -1556,6 +1661,16 @@ assertContract(
     acceptedConnection.getStart() < completedSelection.getStart(),
   connectorSelectionPath,
   "Core wallet selection must connect, make the selected address authoritative, and only then close the chooser",
+);
+assertContract(
+  browserConnectorSelectionGuard &&
+    browserSelectionClosed &&
+    browserConnectorReset &&
+    browserConnectorConnected &&
+    browserSelectionClosed.getStart() < browserConnectorReset.getStart() &&
+    browserConnectorReset.getStart() < browserConnectorConnected.getStart(),
+  connectorSelectionPath,
+  "Browser selection must close the chooser immediately, reset the previous connector session, and only then reconnect",
 );
 
 const browserConnectorConnectPath =

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1355,9 +1355,9 @@ const electronAddDirectOpenGuard = seizeAddConnectedAccount
       (node) =>
         ts.isIfStatement(node) &&
         callsIdentifier(node.expression, "isElectron") &&
+        callsIdentifier(node.thenStatement, "openDesktopAddConnectorChooser") &&
         callsIdentifier(node.thenStatement, "openAddConnectedAccountModal") &&
         callsIdentifier(node.thenStatement, "getWalletAddress") &&
-        callsIdentifier(node.thenStatement, "setIsAddingConnectedAccount") &&
         !callsIdentifier(node.thenStatement, "disconnect") &&
         !callsIdentifier(node.thenStatement, "setActiveWalletAccount") &&
         !callsIdentifier(node.thenStatement, "setConnected") &&
@@ -1366,17 +1366,6 @@ const electronAddDirectOpenGuard = seizeAddConnectedAccount
             ts.isReturnStatement(child),
           ),
         ),
-    )
-  : undefined;
-const electronAddStateReset = electronAddDirectOpenGuard
-  ? findDescendant(
-      electronAddDirectOpenGuard.thenStatement,
-      (node) =>
-        ts.isCallExpression(node) &&
-        ts.isIdentifier(node.expression) &&
-        node.expression.text === "setIsAddingConnectedAccount" &&
-        node.arguments.length === 1 &&
-        node.arguments[0].kind === ts.SyntaxKind.FalseKeyword,
     )
   : undefined;
 const electronAddRefArmed = electronAddDirectOpenGuard
@@ -1400,6 +1389,42 @@ const electronAddOriginMutation = electronAddDirectOpenGuard
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         isMemberExpression(node.left, "addFlowOriginAddressRef", "current"),
+    )
+  : undefined;
+const connectorLifecyclePath =
+  "renderer/components/auth/connector-selection-lifecycle.ts";
+const connectorLifecycle = parseSource(connectorLifecyclePath);
+const openDesktopAddConnectorChooser = findFunction(
+  connectorLifecycle,
+  "openDesktopAddConnectorChooser",
+);
+const desktopAddCandidateCleared = openDesktopAddConnectorChooser
+  ? findDescendant(
+      openDesktopAddConnectorChooser,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "clearAddCandidate",
+    )
+  : undefined;
+const desktopAddStateReset = openDesktopAddConnectorChooser
+  ? findDescendant(
+      openDesktopAddConnectorChooser,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "setAddingConnectedAccount" &&
+        node.arguments.length === 1 &&
+        node.arguments[0].kind === ts.SyntaxKind.FalseKeyword,
+    )
+  : undefined;
+const desktopAddChooserOpened = openDesktopAddConnectorChooser
+  ? findDescendant(
+      openDesktopAddConnectorChooser,
+      (node) =>
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "openChooser",
     )
   : undefined;
 const browserConnectorHandoffRef = findVariable(
@@ -1540,10 +1565,14 @@ assertContract(
 );
 assertContract(
   electronAddDirectOpenGuard &&
-    electronAddStateReset &&
     !electronAddRefArmed &&
-    !electronAddOriginMutation,
-  "renderer/components/auth/SeizeConnectProvider.tsx",
+    !electronAddOriginMutation &&
+    desktopAddCandidateCleared &&
+    desktopAddStateReset &&
+    desktopAddChooserOpened &&
+    desktopAddCandidateCleared.getStart() < desktopAddStateReset.getStart() &&
+    desktopAddStateReset.getStart() < desktopAddChooserOpened.getStart(),
+  connectorLifecyclePath,
   "Electron Add must keep candidate reconciliation disabled, open the chooser, and not disconnect or activate a wallet",
 );
 assertContract(
@@ -1798,15 +1827,22 @@ const useConnectEffectsFunction = findFunction(
   connectEffects,
   "useSeizeConnectProviderEffects",
 );
-const browserHandoffEffectGuard = useConnectEffectsFunction
+const connectorReconciliationEffectGuard = useConnectEffectsFunction
   ? findDescendant(
       useConnectEffectsFunction,
       (node) =>
         ts.isIfStatement(node) &&
+        callsIdentifier(node.expression, "shouldReconcileConnectorState") &&
         referencesMember(
           node.expression,
           "isBrowserConnectorHandoffRef",
           "current",
+        ) &&
+        Boolean(
+          findDescendant(
+            node.expression,
+            (child) => ts.isIdentifier(child) && child.text === "stateOpen",
+          ),
         ) &&
         Boolean(
           findDescendant(node.thenStatement, (child) =>
@@ -1816,9 +1852,9 @@ const browserHandoffEffectGuard = useConnectEffectsFunction
     )
   : undefined;
 assertContract(
-  Boolean(browserHandoffEffectGuard),
+  Boolean(connectorReconciliationEffectGuard),
   connectEffectsPath,
-  "Wallet reconciliation must ignore temporary Wagmi fallback connectors during Browser reconnect handoff",
+  "Wallet reconciliation must ignore existing connectors while the chooser is open or Browser reconnect handoff is active",
 );
 
 const browserConnectorConnectPath =

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1368,7 +1368,7 @@ const electronAddDirectOpenGuard = seizeAddConnectedAccount
         ),
     )
   : undefined;
-const electronAddStateGuard = electronAddDirectOpenGuard
+const electronAddStateReset = electronAddDirectOpenGuard
   ? findDescendant(
       electronAddDirectOpenGuard.thenStatement,
       (node) =>
@@ -1376,10 +1376,10 @@ const electronAddStateGuard = electronAddDirectOpenGuard
         ts.isIdentifier(node.expression) &&
         node.expression.text === "setIsAddingConnectedAccount" &&
         node.arguments.length === 1 &&
-        node.arguments[0].kind === ts.SyntaxKind.TrueKeyword,
+        node.arguments[0].kind === ts.SyntaxKind.FalseKeyword,
     )
   : undefined;
-const electronAddRefGuard = electronAddDirectOpenGuard
+const electronAddRefArmed = electronAddDirectOpenGuard
   ? findDescendant(
       electronAddDirectOpenGuard.thenStatement,
       (node) =>
@@ -1393,15 +1393,13 @@ const electronAddRefGuard = electronAddDirectOpenGuard
         node.right.kind === ts.SyntaxKind.TrueKeyword,
     )
   : undefined;
-const electronAddOriginGuard = electronAddDirectOpenGuard
+const electronAddOriginMutation = electronAddDirectOpenGuard
   ? findDescendant(
       electronAddDirectOpenGuard.thenStatement,
       (node) =>
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        isMemberExpression(node.left, "addFlowOriginAddressRef", "current") &&
-        ts.isIdentifier(node.right) &&
-        node.right.text === "addFlowOriginWallet",
+        isMemberExpression(node.left, "addFlowOriginAddressRef", "current"),
     )
   : undefined;
 const browserConnectorHandoffRef = findVariable(
@@ -1542,11 +1540,11 @@ assertContract(
 );
 assertContract(
   electronAddDirectOpenGuard &&
-    electronAddStateGuard &&
-    electronAddRefGuard &&
-    electronAddOriginGuard,
+    electronAddStateReset &&
+    !electronAddRefArmed &&
+    !electronAddOriginMutation,
   "renderer/components/auth/SeizeConnectProvider.tsx",
-  "Electron Add must preserve the origin, set the add-flow guard true, open the chooser, and not disconnect or activate a wallet",
+  "Electron Add must keep candidate reconciliation disabled, open the chooser, and not disconnect or activate a wallet",
 );
 assertContract(
   browserConnectorHandoffRef &&

--- a/scripts/assert-desktop-renderer-contract.cjs
+++ b/scripts/assert-desktop-renderer-contract.cjs
@@ -1371,6 +1371,29 @@ const connectorSelectorFunction = findFunction(
   connectorModal,
   "ConnectorSelector",
 );
+const connectorOnConnect = connectorSelectorFunction
+  ? findVariable(connectorSelectorFunction, "onConnect")
+  : undefined;
+const awaitedConnectorSelection = connectorOnConnect
+  ? findDescendant(
+      connectorOnConnect,
+      (node) =>
+        ts.isTryStatement(node) &&
+        Boolean(
+          findDescendant(
+            node.tryBlock,
+            (child) =>
+              ts.isAwaitExpression(child) &&
+              callsIdentifier(child.expression, "connectAsync"),
+          ),
+        ) &&
+        Boolean(
+          findDescendant(node.tryBlock, (child) =>
+            isPropertyCall(child, "props", "selected"),
+          ),
+        ),
+    )
+  : undefined;
 assertContract(
   importsModulePrefix(
     connectorModal,
@@ -1392,6 +1415,7 @@ assertContract(
     connectorSelectorFunction &&
     callsIdentifier(connectorSelectorFunction, "getSeedWalletSelectionState") &&
     callsIdentifier(connectorSelectorFunction, "seizeSwitchConnectedAccount") &&
+    Boolean(awaitedConnectorSelection) &&
     jsxAttributeUsesIdentifier(
       connectorSelectorFunction,
       "button",
@@ -1399,7 +1423,29 @@ assertContract(
       "isActive",
     ),
   connectorModalPath,
-  "Core wallet chooser must stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
+  "Core wallet chooser must await new connections before closing, stay wide, disable the active wallet, and switch authenticated wallets without reconnecting",
+);
+
+const browserConnectorConnectPath =
+  "renderer/components/browser-connector/BrowserConnectorConnect.tsx";
+const browserConnectorConnect = parseSource(browserConnectorConnectPath);
+const browserConnectorConnectFunction = findFunction(
+  browserConnectorConnect,
+  "BrowserConnectorConnect",
+);
+assertContract(
+  browserConnectorConnectFunction &&
+    hasJsxElement(browserConnectorConnectFunction, "Button") &&
+    !findDescendant(
+      browserConnectorConnectFunction,
+      (node) =>
+        ts.isStringLiteral(node) &&
+        ["signModalCancelButton", "signModalConfirmButton"].includes(
+          node.text,
+        ),
+    ),
+  browserConnectorConnectPath,
+  "browser-connector authentication actions must use shared styled buttons instead of removed CSS-module classes",
 );
 
 const seizeConnectModalContextPath =

--- a/scripts/resolve-s3-publish-prefix.cjs
+++ b/scripts/resolve-s3-publish-prefix.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const OS_PLACEHOLDER = "${os}";
+
+function resolveS3PublishPrefix(pathTemplate, os) {
+  if (typeof pathTemplate !== "string" || pathTemplate.trim().length === 0) {
+    throw new Error("S3 publish path must be a non-empty string.");
+  }
+  if (typeof os !== "string" || !/^[a-z0-9][a-z0-9_-]*$/i.test(os)) {
+    throw new Error(`Invalid S3 publish OS segment: ${os}`);
+  }
+
+  const expandedPath = pathTemplate.split(OS_PLACEHOLDER).join(os);
+  if (expandedPath.startsWith("/")) {
+    throw new Error("S3 publish path must not start with a slash.");
+  }
+
+  const normalizedPath = expandedPath.replace(/\/+$/, "");
+  if (normalizedPath.length === 0) {
+    throw new Error("S3 publish path must contain a key prefix.");
+  }
+
+  return `${normalizedPath}/`;
+}
+
+if (require.main === module) {
+  const [pathTemplate, os] = process.argv.slice(2);
+  try {
+    process.stdout.write(resolveS3PublishPrefix(pathTemplate, os));
+  } catch (error) {
+    console.error(
+      `[resolve-s3-publish-prefix] ${error instanceof Error ? error.message : error}`,
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = { resolveS3PublishPrefix };


### PR DESCRIPTION
## Summary

- bump the 6529 Core desktop version from `0.3.11` to `0.3.12`
- prepare release metadata for the `v0.3.12` desktop release

## Impact

Desktop packaging and release artifacts will identify this release as version `0.3.12`.

## Validation

- `./bin/6529 ci`
- `./bin/6529 run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux desktop integration metadata for local, staging, and production builds, including application details, categories, and protocol handling.
  * Updated connection dialogs with consistent button styling and improved connector activation feedback.

* **Bug Fixes**
  * Improved release artifact publishing path normalization across macOS, Linux, and staging builds.
  * Improved connection failure handling and ensured connectors complete successfully before selection is confirmed.

* **Tests**
  * Added coverage for publishing paths, Linux desktop configuration, and connection interface requirements.

* **Chores**
  * Updated the application version to 0.3.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->